### PR TITLE
Generally support parameters in stored queries - not only in filters

### DIFF
--- a/ldproxy-cfg/src/main/java/de/ii/ldproxy/cfg/LdproxyCfgImpl.java
+++ b/ldproxy-cfg/src/main/java/de/ii/ldproxy/cfg/LdproxyCfgImpl.java
@@ -16,6 +16,7 @@ import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion.VersionFlag;
 import com.networknt.schema.ValidationMessage;
 import de.ii.ogcapi.features.search.domain.QueryExpression;
+import de.ii.ogcapi.features.search.domain.StoredQueryExpression;
 import de.ii.ogcapi.foundation.domain.OgcApiDataV2;
 import de.ii.ogcapi.styles.domain.MbStyleStylesheet;
 import de.ii.xtraplatform.base.app.StoreImpl;
@@ -471,7 +472,7 @@ class LdproxyCfgImpl implements LdproxyCfg {
       return Codelist.class;
     }
     if (Objects.equals(type, "queries")) {
-      return QueryExpression.class;
+      return StoredQueryExpression.class;
     }
     if (Objects.equals(type, "maplibre-styles")) {
       return MbStyleStylesheet.class;

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/EndpointParameter.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/EndpointParameter.java
@@ -14,11 +14,11 @@ import com.google.common.collect.ImmutableList;
 import de.ii.ogcapi.features.core.domain.EndpointRequiresFeatures;
 import de.ii.ogcapi.features.search.domain.ImmutableQueryInputParameter;
 import de.ii.ogcapi.features.search.domain.ParameterFormat;
-import de.ii.ogcapi.features.search.domain.QueryExpression;
 import de.ii.ogcapi.features.search.domain.SearchConfiguration;
 import de.ii.ogcapi.features.search.domain.SearchQueriesHandler;
 import de.ii.ogcapi.features.search.domain.SearchQueriesHandler.Query;
 import de.ii.ogcapi.features.search.domain.SearchQueriesHandler.QueryInputParameter;
+import de.ii.ogcapi.features.search.domain.StoredQueryExpression;
 import de.ii.ogcapi.features.search.domain.StoredQueryRepository;
 import de.ii.ogcapi.foundation.domain.ApiEndpointDefinition;
 import de.ii.ogcapi.foundation.domain.ApiExtensionHealth;
@@ -156,7 +156,7 @@ public class EndpointParameter extends EndpointRequiresFeatures implements ApiEx
     checkPathParameter(
         extensionRegistry, apiData, "/search/{queryId}/parameters/{name}", "name", name);
 
-    QueryExpression query = repository.get(apiData, queryId);
+    StoredQueryExpression query = repository.get(apiData, queryId);
 
     QueryInputParameter queryInput =
         new ImmutableQueryInputParameter.Builder()

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/EndpointParameters.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/EndpointParameters.java
@@ -14,11 +14,11 @@ import com.google.common.collect.ImmutableList;
 import de.ii.ogcapi.features.core.domain.EndpointRequiresFeatures;
 import de.ii.ogcapi.features.search.domain.ImmutableQueryInputParameters;
 import de.ii.ogcapi.features.search.domain.ParametersFormat;
-import de.ii.ogcapi.features.search.domain.QueryExpression;
 import de.ii.ogcapi.features.search.domain.SearchConfiguration;
 import de.ii.ogcapi.features.search.domain.SearchQueriesHandler;
 import de.ii.ogcapi.features.search.domain.SearchQueriesHandler.Query;
 import de.ii.ogcapi.features.search.domain.SearchQueriesHandler.QueryInputParameters;
+import de.ii.ogcapi.features.search.domain.StoredQueryExpression;
 import de.ii.ogcapi.features.search.domain.StoredQueryRepository;
 import de.ii.ogcapi.foundation.domain.ApiEndpointDefinition;
 import de.ii.ogcapi.foundation.domain.ApiExtensionHealth;
@@ -147,7 +147,7 @@ public class EndpointParameters extends EndpointRequiresFeatures implements ApiE
     checkPathParameter(
         extensionRegistry, apiData, "/search/{queryId}/parameters", "queryId", queryId);
 
-    QueryExpression query = repository.get(apiData, queryId);
+    StoredQueryExpression query = repository.get(apiData, queryId);
 
     QueryInputParameters queryInput =
         new ImmutableQueryInputParameters.Builder()

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/EndpointStoredQueriesManager.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/EndpointStoredQueriesManager.java
@@ -15,12 +15,12 @@ import com.google.common.collect.ImmutableMap;
 import de.ii.ogcapi.collections.domain.ImmutableOgcApiResourceData;
 import de.ii.ogcapi.common.domain.QueryParameterDryRun;
 import de.ii.ogcapi.features.core.domain.EndpointRequiresFeatures;
-import de.ii.ogcapi.features.search.domain.ImmutableQueryExpression;
 import de.ii.ogcapi.features.search.domain.ImmutableQueryInputStoredQueryCreateReplace;
 import de.ii.ogcapi.features.search.domain.ImmutableQueryInputStoredQueryDelete;
-import de.ii.ogcapi.features.search.domain.QueryExpression;
+import de.ii.ogcapi.features.search.domain.ImmutableStoredQueryExpression;
 import de.ii.ogcapi.features.search.domain.SearchConfiguration;
 import de.ii.ogcapi.features.search.domain.SearchQueriesHandler;
+import de.ii.ogcapi.features.search.domain.StoredQueryExpression;
 import de.ii.ogcapi.features.search.domain.StoredQueryFormat;
 import de.ii.ogcapi.foundation.domain.ApiEndpointDefinition;
 import de.ii.ogcapi.foundation.domain.ApiExtensionHealth;
@@ -43,6 +43,7 @@ import de.ii.xtraplatform.auth.domain.User;
 import de.ii.xtraplatform.base.domain.resiliency.Volatile2;
 import io.dropwizard.auth.Auth;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -208,17 +209,17 @@ public class EndpointStoredQueriesManager extends EndpointRequiresFeatures
       @Context OgcApi api,
       @Context ApiRequestContext requestContext,
       @Context HttpServletRequest request,
-      byte[] requestBody) {
+      InputStream requestBody) {
 
     OgcApiDataV2 apiData = api.getData();
     ensureSupportForFeatures(apiData);
     checkPathParameter(extensionRegistry, apiData, "/search/{queryId}", "queryId", queryId);
 
-    QueryExpression query;
+    StoredQueryExpression query;
     try {
       query =
-          new ImmutableQueryExpression.Builder()
-              .from(QueryExpression.of(requestBody))
+          new ImmutableStoredQueryExpression.Builder()
+              .from(StoredQueryExpression.of(requestBody))
               .id(queryId)
               .offset(Optional.empty())
               .build();

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/EndpointStoredQueryDefinition.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/EndpointStoredQueryDefinition.java
@@ -14,11 +14,11 @@ import com.google.common.collect.ImmutableList;
 import de.ii.ogcapi.collections.domain.ImmutableOgcApiResourceData;
 import de.ii.ogcapi.features.core.domain.EndpointRequiresFeatures;
 import de.ii.ogcapi.features.search.domain.ImmutableQueryInputQueryDefinition;
-import de.ii.ogcapi.features.search.domain.QueryExpression;
 import de.ii.ogcapi.features.search.domain.SearchConfiguration;
 import de.ii.ogcapi.features.search.domain.SearchQueriesHandler;
 import de.ii.ogcapi.features.search.domain.SearchQueriesHandler.Query;
 import de.ii.ogcapi.features.search.domain.SearchQueriesHandler.QueryInputQueryDefinition;
+import de.ii.ogcapi.features.search.domain.StoredQueryExpression;
 import de.ii.ogcapi.features.search.domain.StoredQueryFormat;
 import de.ii.ogcapi.features.search.domain.StoredQueryRepository;
 import de.ii.ogcapi.foundation.domain.ApiEndpointDefinition;
@@ -166,7 +166,7 @@ public class EndpointStoredQueryDefinition extends EndpointRequiresFeatures
     checkPathParameter(
         extensionRegistry, apiData, "/search/{queryId}/definition", "queryId", queryId);
 
-    QueryExpression query = repository.get(apiData, queryId);
+    StoredQueryExpression query = repository.get(apiData, queryId);
 
     QueryInputQueryDefinition queryInput =
         new ImmutableQueryInputQueryDefinition.Builder()

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/QueryParameterOffsetStoredQuery.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/QueryParameterOffsetStoredQuery.java
@@ -8,7 +8,7 @@
 package de.ii.ogcapi.features.search.app;
 
 import com.github.azahnen.dagger.annotations.AutoBind;
-import de.ii.ogcapi.features.search.domain.ImmutableQueryExpression;
+import de.ii.ogcapi.features.search.domain.ImmutableStoredQueryExpression;
 import de.ii.ogcapi.features.search.domain.QueryExpressionQueryParameter;
 import de.ii.ogcapi.features.search.domain.SearchConfiguration;
 import de.ii.ogcapi.foundation.domain.ExtensionConfiguration;
@@ -121,7 +121,7 @@ public class QueryParameterOffsetStoredQuery extends OgcApiQueryParameterBase
 
   @Override
   public void applyTo(
-      ImmutableQueryExpression.Builder builder, QueryParameterSet queryParameterSet) {
+      ImmutableStoredQueryExpression.Builder builder, QueryParameterSet queryParameterSet) {
     builder.offset(queryParameterSet.getValue(this));
   }
 }

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/SearchBuildingBlock.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/SearchBuildingBlock.java
@@ -84,6 +84,8 @@ import javax.inject.Singleton;
  *     converted to an array, if the parameter is of type "array".
  * - Parameters may also be provided in a member "parameters" in the query expression and
  *     referenced using "$ref".
+ * - Parameters may be used in all members of the query expression, except "id", "title",
+ *     "description", and "offset".
  *     </code>
  * @scopeDe Dieser Baustein unterstützt die Suche nach Features aus einer oder mehreren Collections.
  *     Das heißt, es unterstützt Abfragen, die mit den Filtermechanismen, die durch die Bausteine
@@ -124,6 +126,7 @@ import javax.inject.Singleton;
  * - "sortby" wird nur pro Abfrage angewendet. Ein globales "sortby" würde erfordern, dass die Ergebnisse aller Abfragen zuerst kompiliert werden und dann die kombinierte Ergebnismenge sortiert wird. Dies würde das "Streaming" der Antwort nicht unterstützen.
  * - Im Falle einer parametrisierten gespeicherten Abfrage kann der Abfrageausdruck JSON-Objekte mit einem Member "$parameter" enthalten. Der Wert von "$parameter" ist ein Objekt mit einem Key-Value-Paar, bei dem der Schlüssel der Parametername und der Wert ein JSON-Schema ist, das den Parameter beschreibt. Bei der Ausführung der gespeicherten Abfrage werden alle Objekte mit einem "$parameter"-Member durch den Wert des Parameters für diese Abfrageausführung ersetzt. Kommagetrennte Parameterwerte werden in ein Array umgewandelt, wenn der Parameter vom Typ "array" ist.
  * - Parameter können auch in einem Member "parameters" im Abfrageausdruck angegeben werden und mit "$ref" referenziert werden.
+ * - Parameter können in allen Membern der Query Expression verwendet werden, außer in "id", "title", "description" und "offset".
  *     </code>
  * @conformanceEn This building block implements the OGC API Features extensions specified in
  *     chapters 5 and 6 of the [OGC Testbed-18 Filtering Service and Rule Set Engineering
@@ -135,7 +138,6 @@ import javax.inject.Singleton;
  *     sich im Zuge der weiteren Standardisierung der Spezifikation noch ändern.
  * @limitationsEn Parameterized stored queries have the following constraints:
  *     <p><code>
- * - Parameters can only occur in filter expressions.
  * - The JSON Schema of a parameter supports a subset of the language. In particular,
  *     `patternProperties`, `additionalProperties`, `allOf`, `oneOf`, `prefixItems`,
  *     `additionalItems` and `items: false` are not supported.
@@ -149,7 +151,6 @@ import javax.inject.Singleton;
  *     </code>
  * @limitationsDe Für parametrisierte gespeicherte Abfragen gelten die folgenden Beschränkungen:
  *     <p><code>
- * - Parameter können nur in Filterausdrücken vorkommen.
  * - Das JSON-Schema eines Parameters unterstützt eine Teilmenge der Sprache. Insbesondere werden `patternProperties`, `additionalProperties`, `allOf`, `oneOf`, `prefixItems`, `additionalItems` und `items: false` nicht unterstützt.
  * - POST zur Ausführung einer gespeicherten Abfrage wird nicht unterstützt. Dies wird hinzugefügt, nachdem die Spezifikation in OGC diskutiert wurde (z.B. ob die Nutzlast JSON oder URL-kodierte Abfrageparameter sein sollen).
  *     </code>

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/StoredQueryExpressionFactory.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/StoredQueryExpressionFactory.java
@@ -8,17 +8,17 @@
 package de.ii.ogcapi.features.search.app;
 
 import com.github.azahnen.dagger.annotations.AutoBind;
-import de.ii.ogcapi.features.search.domain.QueryExpression;
+import de.ii.ogcapi.features.search.domain.StoredQueryExpression;
 import de.ii.xtraplatform.values.domain.ValueFactoryAuto;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
 @AutoBind
-public class QueryExpressionFactory extends ValueFactoryAuto {
+public class StoredQueryExpressionFactory extends ValueFactoryAuto {
 
   @Inject
-  QueryExpressionFactory() {
-    super(QueryExpression.class);
+  StoredQueryExpressionFactory() {
+    super(StoredQueryExpression.class);
   }
 }

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/StoredQueryFormatJson.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/StoredQueryFormatJson.java
@@ -8,7 +8,7 @@
 package de.ii.ogcapi.features.search.app;
 
 import com.github.azahnen.dagger.annotations.AutoBind;
-import de.ii.ogcapi.features.search.domain.QueryExpression;
+import de.ii.ogcapi.features.search.domain.StoredQueryExpression;
 import de.ii.ogcapi.features.search.domain.StoredQueryFormat;
 import de.ii.ogcapi.foundation.domain.ApiMediaType;
 import de.ii.ogcapi.foundation.domain.ApiMediaTypeContent;
@@ -40,8 +40,8 @@ public class StoredQueryFormatJson implements StoredQueryFormat {
 
   @Inject
   public StoredQueryFormatJson(ClassSchemaCache classSchemaCache) {
-    this.schema = classSchemaCache.getSchema(QueryExpression.class);
-    referencedSchemas = classSchemaCache.getReferencedSchemas(QueryExpression.class);
+    this.schema = classSchemaCache.getSchema(StoredQueryExpression.class);
+    referencedSchemas = classSchemaCache.getReferencedSchemas(StoredQueryExpression.class);
   }
 
   @Override
@@ -53,7 +53,7 @@ public class StoredQueryFormatJson implements StoredQueryFormat {
   public ApiMediaTypeContent getContent() {
     return new ImmutableApiMediaTypeContent.Builder()
         .schema(schema)
-        .schemaRef(QueryExpression.SCHEMA_REF)
+        .schemaRef(StoredQueryExpression.SCHEMA_REF)
         .referencedSchemas(referencedSchemas)
         .ogcApiMediaType(MEDIA_TYPE)
         .build();
@@ -71,7 +71,7 @@ public class StoredQueryFormatJson implements StoredQueryFormat {
 
   @Override
   public Object getEntity(
-      QueryExpression query, OgcApiDataV2 apiData, ApiRequestContext requestContext) {
+      StoredQueryExpression query, OgcApiDataV2 apiData, ApiRequestContext requestContext) {
     return query;
   }
 }

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/StoredQueryRepositoryImpl.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/StoredQueryRepositoryImpl.java
@@ -9,8 +9,8 @@ package de.ii.ogcapi.features.search.app;
 
 import com.github.azahnen.dagger.annotations.AutoBind;
 import com.google.common.collect.ImmutableList;
-import de.ii.ogcapi.features.search.domain.QueryExpression;
 import de.ii.ogcapi.features.search.domain.StoredQueriesFormat;
+import de.ii.ogcapi.features.search.domain.StoredQueryExpression;
 import de.ii.ogcapi.features.search.domain.StoredQueryFormat;
 import de.ii.ogcapi.features.search.domain.StoredQueryRepository;
 import de.ii.ogcapi.foundation.domain.ApiMediaType;
@@ -47,7 +47,7 @@ public class StoredQueryRepositoryImpl extends AbstractVolatile
   private static final Logger LOGGER = LoggerFactory.getLogger(StoredQueryRepositoryImpl.class);
 
   private final ExtensionRegistry extensionRegistry;
-  private final KeyValueStore<QueryExpression> queriesStore;
+  private final KeyValueStore<StoredQueryExpression> queriesStore;
   private final VolatileRegistry volatileRegistry;
 
   @Inject
@@ -57,7 +57,7 @@ public class StoredQueryRepositoryImpl extends AbstractVolatile
       VolatileRegistry volatileRegistry) {
     super(volatileRegistry, "app/storedqueries");
     this.extensionRegistry = extensionRegistry;
-    this.queriesStore = valueStore.forTypeWritable(QueryExpression.class);
+    this.queriesStore = valueStore.forTypeWritable(StoredQueryExpression.class);
     this.volatileRegistry = volatileRegistry;
   }
 
@@ -91,14 +91,14 @@ public class StoredQueryRepositoryImpl extends AbstractVolatile
   }
 
   @Override
-  public List<QueryExpression> getAll(OgcApiDataV2 apiData) {
+  public List<StoredQueryExpression> getAll(OgcApiDataV2 apiData) {
     return queriesStore.identifiers(apiData.getId()).stream()
         .map(queriesStore::get)
         .collect(ImmutableList.toImmutableList());
   }
 
   @Override
-  public QueryExpression get(OgcApiDataV2 apiData, String queryId) {
+  public StoredQueryExpression get(OgcApiDataV2 apiData, String queryId) {
     if (!exists(apiData, queryId)) {
       throw new NotFoundException(
           MessageFormat.format("The stored query ''{0}'' does not exist in this API.", queryId));
@@ -152,13 +152,13 @@ public class StoredQueryRepositoryImpl extends AbstractVolatile
   @Override
   public Set<String> getIds(OgcApiDataV2 apiData) {
     return getAll(apiData).stream()
-        .map(QueryExpression::getId)
+        .map(StoredQueryExpression::getId)
         .collect(Collectors.toUnmodifiableSet());
   }
 
   @Override
-  public void writeStoredQueryDocument(OgcApiDataV2 apiData, String queryId, QueryExpression query)
-      throws IOException {
+  public void writeStoredQueryDocument(
+      OgcApiDataV2 apiData, String queryId, StoredQueryExpression query) throws IOException {
     try {
       queriesStore.put(queryId, query, apiData.getId()).join();
     } catch (CompletionException e) {

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/QueryExpression.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/QueryExpression.java
@@ -8,76 +8,24 @@
 package de.ii.ogcapi.features.search.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.hash.Funnel;
-import de.ii.ogcapi.foundation.domain.QueryParameterSet;
-import de.ii.ogcapi.foundation.domain.SchemaValidator;
-import de.ii.xtraplatform.values.domain.StoredValue;
-import de.ii.xtraplatform.values.domain.ValueBuilder;
-import de.ii.xtraplatform.values.domain.annotations.FromValueStore;
-import io.swagger.v3.oas.models.media.ArraySchema;
-import io.swagger.v3.oas.models.media.BooleanSchema;
-import io.swagger.v3.oas.models.media.IntegerSchema;
-import io.swagger.v3.oas.models.media.NumberSchema;
-import io.swagger.v3.oas.models.media.ObjectSchema;
-import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.media.StringSchema;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.BadRequestException;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @Value.Style(jdkOnly = true, deepImmutablesDetection = true, builder = "new")
-@FromValueStore(type = "queries")
 @JsonDeserialize(builder = ImmutableQueryExpression.Builder.class)
-@SuppressWarnings("PMD.TooManyMethods")
-public interface QueryExpression extends StoredValue {
+public interface QueryExpression {
 
   String ADHOC_QUERY_ID = "_adhoc_query_";
-
-  @SuppressWarnings("UnstableApiUsage")
-  Funnel<QueryExpression> FUNNEL =
-      (from, into) -> {
-        into.putString(from.getId(), StandardCharsets.UTF_8);
-        from.getTitle().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
-        from.getDescription().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
-        from.getQueries().forEach(q -> SingleQuery.FUNNEL.funnel(q, into));
-        from.getCollections().forEach(s -> into.putString(s, StandardCharsets.UTF_8));
-        from.getFilter().forEach((key, value) -> into.putString(key, StandardCharsets.UTF_8));
-        from.getFilterOperator().ifPresent(v -> into.putString(v.name(), StandardCharsets.UTF_8));
-        from.getSortby().forEach(s -> into.putString(s, StandardCharsets.UTF_8));
-        from.getProperties().forEach(s -> into.putString(s, StandardCharsets.UTF_8));
-        from.getCrs().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
-        from.getVerticalCrs().ifPresent(s -> into.putString(s, StandardCharsets.UTF_8));
-        from.getMaxAllowableOffset().ifPresent(into::putDouble);
-        from.getLimit().ifPresent(into::putInt);
-        from.getOffset().ifPresent(into::putInt);
-        from.getProfiles().forEach(s -> into.putString(s, StandardCharsets.UTF_8));
-      };
 
   ObjectMapper MAPPER =
       new ObjectMapper()
@@ -87,19 +35,13 @@ public interface QueryExpression extends StoredValue {
           .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   String SCHEMA_REF = "#/components/schemas/QueryExpression";
-  String REF = "$ref";
-  String PARAMETER = "$parameter";
 
   enum FilterOperator {
     AND,
     OR
   }
 
-  abstract class Builder implements ValueBuilder<QueryExpression> {}
-
-  static QueryExpression of(byte[] requestBody) throws IOException {
-    return MAPPER.readValue(requestBody, QueryExpression.class);
-  }
+  abstract class Builder {}
 
   static QueryExpression of(InputStream requestBody) throws IOException {
     return MAPPER.readValue(requestBody, QueryExpression.class);
@@ -116,597 +58,38 @@ public interface QueryExpression extends StoredValue {
 
   List<SingleQuery> getQueries();
 
-  List<String> getCollections(); // String or Parameter
+  List<String> getCollections();
 
-  Map<String, Object> getFilter();
+  Optional<Object> getFilter();
 
   Optional<String> getFilterCrs();
 
   Optional<FilterOperator> getFilterOperator();
 
-  List<String> getSortby(); // String or Parameter
+  List<String> getSortby();
 
-  List<String> getProperties(); // String or Parameter
+  List<String> getProperties();
 
-  Optional<String> getCrs(); // String or Parameter
+  Optional<String> getCrs();
 
-  Optional<String> getVerticalCrs(); // String or Parameter
+  Optional<String> getVerticalCrs();
 
-  Optional<Double> getMaxAllowableOffset(); // Double or Parameter
+  Optional<Double> getMaxAllowableOffset();
 
-  Optional<Integer> getLimit(); // Integer or Parameter
+  Optional<Integer> getLimit();
 
   Optional<Integer> getOffset();
 
   List<String> getProfiles();
 
-  Map<String, JsonNode> getParameters();
-
+  @JsonIgnore
   @Value.Check
   default void check() {
     Preconditions.checkState(
         getQueries().isEmpty() && getCollections().size() == 1
             || !getQueries().isEmpty() && getCollections().isEmpty(),
-        "Either one or more queries must be provided or a single collection. Query: %s. Collections: %s.",
+        "Either one or more queries must be provided or a single collection. Queries: %s. Collections: %s.",
         getQueries(),
         getCollections());
-  }
-
-  @JsonIgnore
-  @Value.Derived
-  @Value.Auxiliary
-  default boolean hasParameters() {
-    return !getParameterNames().isEmpty();
-  }
-
-  @JsonIgnore
-  @Value.Derived
-  @Value.Auxiliary
-  default Set<String> getParameterNames() {
-    ImmutableSet.Builder<String> builder = ImmutableSet.builder();
-    builder.addAll(getParameterNamesFromFilter(getFilterAsNode(getFilter())));
-    for (SingleQuery q : getQueries()) {
-      builder.addAll(getParameterNamesFromFilter(getFilterAsNode(q.getFilter())));
-    }
-    return builder.build();
-  }
-
-  @JsonIgnore
-  @Value.Derived
-  @Value.Auxiliary
-  default Map<String, JsonNode> getParametersAsNodes() {
-    Map<String, JsonNode> params =
-        getParametersFromFilter(getFilterAsNode(getFilter()), getParameters());
-    for (SingleQuery q : getQueries()) {
-      params =
-          mergeMaps(
-              params, getParametersFromFilter(getFilterAsNode(q.getFilter()), getParameters()));
-    }
-    return params;
-  }
-
-  @JsonIgnore
-  @Value.Derived
-  @Value.Auxiliary
-  default Map<String, Schema<?>> getParametersWithOpenApiSchema() {
-    ImmutableMap.Builder<String, Schema<?>> paramBuilder = ImmutableMap.builder();
-    getParametersAsNodes().forEach((key, value) -> paramBuilder.put(key, deriveSchema(value)));
-    return paramBuilder.build();
-  }
-
-  default QueryExpression resolveParameters(
-      QueryParameterSet queryParameterSet, SchemaValidator schemaValidator) {
-    Map<String, JsonNode> params = getParametersAsNodes();
-    if (!params.isEmpty()) {
-      ImmutableMap.Builder<String, JsonNode> builder = ImmutableMap.builder();
-      JsonNode valueAsNode;
-      for (Map.Entry<String, JsonNode> entry : params.entrySet()) {
-
-        // get the JSON Schema of the parameter as a string for validation
-        String schemaAsString;
-        try {
-          schemaAsString = MAPPER.writeValueAsString(entry.getValue());
-        } catch (JsonProcessingException e) {
-          throw new IllegalStateException(
-              String.format(
-                  "Could not read the schema of parameter '%s' in a query.", entry.getKey()),
-              e);
-        }
-
-        // get value as node (for the result)
-        if (queryParameterSet.getTypedValues().containsKey(entry.getKey())) {
-          valueAsNode = (JsonNode) queryParameterSet.getTypedValues().get(entry.getKey());
-        } else {
-          // no value provided, use default or throw an exception
-          valueAsNode = useDefault(entry);
-        }
-
-        validateParameter(schemaValidator, valueAsNode, entry, schemaAsString);
-        builder.put(entry.getKey(), valueAsNode);
-      }
-
-      ObjectNode queryNode = MAPPER.valueToTree(this);
-      replaceParameters(queryNode, builder.build());
-      queryNode.remove("parameters");
-      try {
-        return MAPPER.treeToValue(queryNode, QueryExpression.class);
-      } catch (JsonProcessingException e) {
-        throw new IllegalStateException(e);
-      }
-    }
-    return this;
-  }
-
-  @SuppressWarnings("PMD.NullAssignment")
-  private JsonNode getValue(
-      String value, StringBuilder valueAsString, Entry<String, JsonNode> entry) {
-    JsonNode valueAsNode;
-    Schema<?> schema = deriveSchema(entry.getValue());
-    if (schema instanceof ArraySchema && !value.trim().startsWith("[")) {
-      Schema<?> itemsSchema = ((ArraySchema) schema).getItems();
-      if (itemsSchema instanceof StringSchema) {
-        valueAsString.append(
-            String.format(
-                "[\"%s\"]",
-                Splitter.on(',')
-                    .trimResults()
-                    .splitToStream(value)
-                    .map(s -> s.replace("\"", "\\\""))
-                    .collect(Collectors.joining("\",\""))));
-      } else {
-        valueAsString.append(
-            String.format(
-                "[%s]",
-                Splitter.on(',')
-                    .trimResults()
-                    .splitToStream(value)
-                    .map(s -> s.replace("\"", "\\\""))
-                    .collect(Collectors.joining(","))));
-      }
-    } else if (schema instanceof ObjectSchema && !value.trim().startsWith("{")) {
-      Map<String, Schema> properties = schema.getProperties();
-      valueAsString.append('{');
-      String key = null;
-      for (String s : Splitter.on(',').trimResults().split(value)) {
-        if (Objects.isNull(key)) {
-          key = s;
-          valueAsString.append(String.format("\"%s\":", s));
-        } else {
-          if (properties.containsKey(key) && properties.get(key) instanceof StringSchema) {
-            valueAsString.append(String.format("\"%s\"", s));
-          } else {
-            valueAsString.append(s);
-          }
-          key = null;
-        }
-      }
-      valueAsString.append('}');
-
-    } else {
-      if (schema instanceof StringSchema) {
-        valueAsString.append(String.format("\"%s\"", value.replace("\"", "\\\"")));
-      } else {
-        valueAsString.append(value);
-      }
-    }
-    try {
-      // convert to a JSON Node for processing
-      valueAsNode = MAPPER.readTree(valueAsString.toString());
-    } catch (JsonProcessingException e) {
-      throw new BadRequestException(
-          String.format(
-              "The value '%s' provided for parameter '%s' could not be converted to a value for the parameter.",
-              value, entry.getKey()),
-          e);
-    }
-    return valueAsNode;
-  }
-
-  private JsonNode useDefault(Entry<String, JsonNode> entry) {
-    JsonNode valueAsNode;
-    valueAsNode = entry.getValue().get("default");
-    if (Objects.isNull(valueAsNode) || valueAsNode.isNull()) {
-      throw new BadRequestException(
-          String.format("No value provided for parameter '%s'.", entry.getKey()));
-    }
-    return valueAsNode;
-  }
-
-  private void validateParameter(
-      SchemaValidator schemaValidator,
-      JsonNode valueAsNode,
-      Entry<String, JsonNode> entry,
-      String schemaAsString) {
-    final String value;
-    try {
-      // convert to string for validation
-      value = MAPPER.writeValueAsString(valueAsNode);
-    } catch (JsonProcessingException e) {
-      throw new IllegalStateException(
-          String.format(
-              "The JSON value derived for parameter '%s' could not be converted to a string value for validation.",
-              entry.getKey()),
-          e);
-    }
-    // validate parameter
-    try {
-      schemaValidator
-          .validate(schemaAsString, value)
-          .ifPresent(
-              error -> {
-                throw new BadRequestException(
-                    String.format(
-                        "Parameter '%s' is invalid, the value '%s' does not conform to the schema '%s'. Reason: %s",
-                        entry.getKey(), value, schemaAsString, error));
-              });
-    } catch (IOException e) {
-      throw new IllegalStateException(
-          String.format(
-              "Could not validate value '%s' of parameter '%s' against its schema '%s'",
-              value, entry.getKey(), schemaAsString),
-          e);
-    }
-  }
-
-  private Schema<?> deriveSchema(@NotNull JsonNode schemaNode) {
-    if (!schemaNode.isObject()) {
-      throw new IllegalArgumentException(
-          String.format("Found a parameter without a schema object. Found %s", schemaNode));
-    }
-
-    Schema<?> schema;
-    if (Objects.nonNull(schemaNode.get(REF))) {
-      schema = new ObjectSchema();
-      schema.$ref(schemaNode.get(REF).asText());
-    } else if (Objects.isNull(schemaNode.get("type"))) {
-      throw new IllegalArgumentException(
-          "Found a parameter without a 'type' member in the schema.");
-    } else {
-      switch (schemaNode.get("type").asText()) {
-        case "object":
-          schema = getObjectSchema(schemaNode);
-          break;
-        case "array":
-          schema = getArraySchema(schemaNode);
-          break;
-        case "string":
-          schema = getStringSchema(schemaNode);
-          break;
-        case "number":
-          schema = getNumberSchema(schemaNode);
-          break;
-        case "integer":
-          schema = getIntegerSchema(schemaNode);
-          break;
-        case "boolean":
-          schema = new BooleanSchema();
-          break;
-        default:
-          throw new IllegalArgumentException(
-              String.format(
-                  "Found unsupported 'type'. Found: %s", schemaNode.get("type").asText()));
-      }
-    }
-    setMetadata(schemaNode, schema);
-    return schema;
-  }
-
-  private Schema<?> getObjectSchema(JsonNode schemaNode) {
-    ObjectSchema schema = new ObjectSchema();
-    ObjectNode properties = (ObjectNode) schemaNode.get("properties");
-    if (Objects.nonNull(properties)) {
-      JsonNode node = schemaNode.get("required");
-      if (Objects.nonNull(node)) {
-        Iterator<JsonNode> iter = node.elements();
-        while (iter.hasNext()) {
-          schema.addRequiredItem(iter.next().asText());
-        }
-      }
-      Iterator<Entry<String, JsonNode>> iter = properties.fields();
-      while (iter.hasNext()) {
-        Entry<String, JsonNode> entry = iter.next();
-        schema.addProperties(entry.getKey(), deriveSchema(entry.getValue()));
-      }
-      node = schemaNode.get("minProperties");
-      if (Objects.nonNull(node)) {
-        schema.minProperties(node.asInt());
-      }
-      node = schemaNode.get("maxProperties");
-      if (Objects.nonNull(node)) {
-        schema.maxProperties(node.asInt());
-      }
-    }
-    // see limitation, not supported: patternProperties, additionalProperties, allOf, oneOf
-    return schema;
-  }
-
-  private Schema<?> getArraySchema(JsonNode schemaNode) {
-    ArraySchema schema = new ArraySchema();
-    JsonNode node = schemaNode.get("items");
-    if (Objects.nonNull(node)) {
-      schema.items(deriveSchema(node));
-    }
-    node = schemaNode.get("minItems");
-    if (Objects.nonNull(node)) {
-      schema.minItems(node.asInt());
-    }
-    node = schemaNode.get("maxItems");
-    if (Objects.nonNull(node)) {
-      schema.maxItems(node.asInt());
-    }
-    node = schemaNode.get("uniqueObject");
-    if (Objects.nonNull(node)) {
-      schema.uniqueItems(node.asBoolean());
-    }
-    // see limitation, not supported: prefixItems, additionalItems, items:false
-    return schema;
-  }
-
-  private Schema<?> getStringSchema(JsonNode schemaNode) {
-    StringSchema schema = new StringSchema();
-    JsonNode node = schemaNode.get("format");
-    if (Objects.nonNull(node)) {
-      schema.format(node.asText());
-    }
-    node = schemaNode.get("minLength");
-    if (Objects.nonNull(node)) {
-      schema.minLength(node.asInt());
-    }
-    node = schemaNode.get("maxLength");
-    if (Objects.nonNull(node)) {
-      schema.maxLength(node.asInt());
-    }
-    node = schemaNode.get("pattern");
-    if (Objects.nonNull(node)) {
-      schema.pattern(node.asText());
-    }
-    JsonNode enums = schemaNode.get("enum");
-    if (Objects.nonNull(enums)) {
-      Iterator<JsonNode> iter = enums.elements();
-      while (iter.hasNext()) {
-        schema.addEnumItem(iter.next().asText());
-      }
-    }
-    return schema;
-  }
-
-  private Schema<?> getNumberSchema(JsonNode schemaNode) {
-    NumberSchema schema = new NumberSchema();
-    JsonNode node = schemaNode.get("multipleOf");
-    if (Objects.nonNull(node)) {
-      schema.multipleOf(node.decimalValue());
-    }
-    node = schemaNode.get("minimum");
-    if (Objects.nonNull(node)) {
-      schema.minimum(node.decimalValue());
-    }
-    node = schemaNode.get("exclusiveMinimum");
-    if (Objects.nonNull(node)) {
-      schema.minimum(node.decimalValue());
-      schema.exclusiveMinimum(true);
-    }
-    node = schemaNode.get("maximum");
-    if (Objects.nonNull(node)) {
-      schema.maximum(node.decimalValue());
-    }
-    node = schemaNode.get("exclusiveMaximum");
-    if (Objects.nonNull(node)) {
-      schema.maximum(node.decimalValue());
-      schema.exclusiveMaximum(true);
-    }
-    JsonNode enums = schemaNode.get("enum");
-    if (Objects.nonNull(enums)) {
-      Iterator<JsonNode> iter = enums.elements();
-      while (iter.hasNext()) {
-        schema.addEnumItem(iter.next().decimalValue());
-      }
-    }
-    return schema;
-  }
-
-  private Schema<?> getIntegerSchema(JsonNode schemaNode) {
-    IntegerSchema schema = new IntegerSchema();
-    JsonNode node = schemaNode.get("multipleOf");
-    if (Objects.nonNull(node)) {
-      schema.multipleOf(node.decimalValue());
-    }
-    node = schemaNode.get("minimum");
-    if (Objects.nonNull(node)) {
-      schema.minimum(node.decimalValue());
-    }
-    node = schemaNode.get("exclusiveMinimum");
-    if (Objects.nonNull(node)) {
-      schema.minimum(node.decimalValue());
-      schema.exclusiveMinimum(true);
-    }
-    node = schemaNode.get("maximum");
-    if (Objects.nonNull(node)) {
-      schema.maximum(node.decimalValue());
-    }
-    node = schemaNode.get("exclusiveMaximum");
-    if (Objects.nonNull(node)) {
-      schema.maximum(node.decimalValue());
-      schema.exclusiveMaximum(true);
-    }
-    JsonNode enums = schemaNode.get("enum");
-    if (Objects.nonNull(enums)) {
-      Iterator<JsonNode> iter = enums.elements();
-      while (iter.hasNext()) {
-        schema.addEnumItem(iter.next().decimalValue());
-      }
-    }
-    return schema;
-  }
-
-  private void setMetadata(JsonNode schemaNode, Schema<?> schema) {
-    JsonNode node = schemaNode.get("title");
-    if (Objects.nonNull(node)) {
-      schema.title(node.asText());
-    }
-    node = schemaNode.get("description");
-    if (Objects.nonNull(node)) {
-      schema.description(node.asText());
-    }
-    node = schemaNode.get("example");
-    if (Objects.nonNull(node)) {
-      try {
-        schema.example(MAPPER.treeToValue(node, Object.class));
-      } catch (JsonProcessingException e) {
-        throw new IllegalStateException(e);
-      }
-    }
-    node = schemaNode.get("default");
-    if (Objects.nonNull(node)) {
-      try {
-        schema.setDefault(MAPPER.treeToValue(node, Object.class));
-      } catch (JsonProcessingException e) {
-        throw new IllegalStateException(e);
-      }
-    }
-  }
-
-  private boolean isParameterNode(JsonNode node) {
-    return Objects.nonNull(node) && node.isObject() && Objects.nonNull(node.get(PARAMETER));
-  }
-
-  private String getParameterName(JsonNode valueNode) {
-    if (Objects.nonNull(valueNode) && valueNode.isObject()) {
-      if (valueNode.fields().hasNext()) {
-        Entry<String, JsonNode> firstMember = valueNode.fields().next();
-        if (REF.equals(firstMember.getKey())) {
-          if (firstMember.getValue().isTextual()
-              && firstMember.getValue().textValue().startsWith("#/parameters/")) {
-            return firstMember.getValue().textValue().substring(13);
-          } else {
-            throw new IllegalArgumentException(
-                String.format(
-                    "Found '$ref' object where the value is not a JSON Reference to a member in '#/parameters'. Found: %s",
-                    firstMember.getValue()));
-          }
-        } else {
-          return firstMember.getKey();
-        }
-      } else {
-        throw new IllegalArgumentException(
-            "Found empty '$parameter' object. Either the JSON Schema of the parameter must be provided or a JSON Reference to the top-level 'parameters' member.");
-      }
-    }
-
-    throw new IllegalArgumentException(
-        String.format(
-            "Illegal value of a '$parameter' key. The value must be either a local JSON Reference to a parameter defined in the 'parameters' member or a JSON Schema object. Found: %s",
-            valueNode));
-  }
-
-  private void replaceParameters(JsonNode node, Map<String, JsonNode> params) {
-    if (Objects.nonNull(node)) {
-      if (node.isArray()) {
-        ArrayNode arrayNode = (ArrayNode) node;
-        for (int i = 0; i < arrayNode.size(); i++) {
-          if (isParameterNode(arrayNode.get(i))) {
-            arrayNode.set(i, params.get(getParameterName(arrayNode.get(i).get(PARAMETER))));
-          } else {
-            replaceParameters(arrayNode.get(i), params);
-          }
-        }
-      } else if (node.isObject()) {
-        ObjectNode objectNode = (ObjectNode) node;
-        Iterator<Entry<String, JsonNode>> iter = objectNode.fields();
-        while (iter.hasNext()) {
-          Map.Entry<String, JsonNode> entry = iter.next();
-          if (isParameterNode(entry.getValue())) {
-            objectNode.set(
-                entry.getKey(), params.get(getParameterName(entry.getValue().get(PARAMETER))));
-          } else {
-            replaceParameters(entry.getValue(), params);
-          }
-        }
-      } else if (!node.isNull() && !node.isValueNode()) {
-        throw new IllegalStateException(
-            String.format("Support for schema type %s not implemented.", node.getNodeType()));
-      }
-    }
-  }
-
-  private Map<String, JsonNode> getParametersFromFilter(
-      JsonNode node, Map<String, JsonNode> predefinedParameters) {
-    if (Objects.isNull(node)) {
-      return ImmutableMap.of();
-    }
-
-    Map<String, JsonNode> params = ImmutableMap.of();
-    if (node.isArray()) {
-      ArrayNode arrayNode = (ArrayNode) node;
-      for (int i = 0; i < arrayNode.size(); i++) {
-        params = mergeMaps(params, getParametersFromFilter(arrayNode.get(i), predefinedParameters));
-      }
-    } else if (node.isObject()) {
-      JsonNode param = node.get(PARAMETER);
-      if (Objects.isNull(param)) {
-        ObjectNode objectNode = (ObjectNode) node;
-        Iterator<Map.Entry<String, JsonNode>> iter = objectNode.fields();
-        while (iter.hasNext()) {
-          Map.Entry<String, JsonNode> entry = iter.next();
-          params =
-              mergeMaps(params, getParametersFromFilter(entry.getValue(), predefinedParameters));
-        }
-      } else if (param.isObject()) {
-        String name = getParameterName(param);
-        // ignore multiple definitions of the same parameter
-        if (!params.containsKey(name)) {
-          Map.Entry<String, JsonNode> entry = param.fields().next();
-          if (REF.equals(entry.getKey())) {
-            if (predefinedParameters.containsKey(name)) {
-              params = mergeMaps(params, ImmutableMap.of(name, predefinedParameters.get(name)));
-            } else {
-              throw new IllegalArgumentException(
-                  String.format(
-                      "Undefined parameter '%s' referenced in query.", param.textValue()));
-            }
-          } else {
-            params = mergeMaps(params, ImmutableMap.of(entry.getKey(), entry.getValue()));
-          }
-        }
-      }
-    }
-    return params;
-  }
-
-  private Map<String, JsonNode> mergeMaps(
-      Map<String, JsonNode> current, Map<String, JsonNode> additional) {
-    return Stream.of(current, additional)
-        .flatMap(map -> map.entrySet().stream())
-        .collect(Collectors.toMap(Entry::getKey, Entry::getValue, (n1, n2) -> n1));
-  }
-
-  private Set<String> getParameterNamesFromFilter(JsonNode node) {
-    if (Objects.isNull(node)) {
-      return ImmutableSet.of();
-    }
-
-    ImmutableSet.Builder<String> builder = new ImmutableSet.Builder<>();
-    if (node.isArray()) {
-      ArrayNode arrayNode = (ArrayNode) node;
-      for (int i = 0; i < arrayNode.size(); i++) {
-        builder.addAll(getParameterNamesFromFilter(arrayNode.get(i)));
-      }
-    } else if (node.isObject()) {
-      JsonNode param = node.get(PARAMETER);
-      if (Objects.isNull(param)) {
-        ObjectNode objectNode = (ObjectNode) node;
-        Iterator<Map.Entry<String, JsonNode>> iter = objectNode.fields();
-        while (iter.hasNext()) {
-          Map.Entry<String, JsonNode> entry = iter.next();
-          builder.addAll(getParameterNamesFromFilter(entry.getValue()));
-        }
-      } else if (param.isObject()) {
-        builder.add(getParameterName(param));
-      }
-    }
-    return builder.build();
-  }
-
-  private JsonNode getFilterAsNode(Map<String, Object> filter) {
-    return MAPPER.valueToTree(filter);
   }
 }

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/QueryExpressionQueryParameter.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/QueryExpressionQueryParameter.java
@@ -13,5 +13,5 @@ import de.ii.ogcapi.foundation.domain.QueryParameterSet;
 @AutoMultiBind
 public interface QueryExpressionQueryParameter {
 
-  void applyTo(ImmutableQueryExpression.Builder builder, QueryParameterSet queryParameterSet);
+  void applyTo(ImmutableStoredQueryExpression.Builder builder, QueryParameterSet queryParameterSet);
 }

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/SearchQueriesHandler.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/SearchQueriesHandler.java
@@ -75,21 +75,21 @@ public interface SearchQueriesHandler
   interface QueryInputQueryDefinition extends QueryInput {
     String getQueryId();
 
-    QueryExpression getQuery();
+    StoredQueryExpression getQuery();
   }
 
   @Value.Immutable
   interface QueryInputParameters extends QueryInput {
     String getQueryId();
 
-    QueryExpression getQuery();
+    StoredQueryExpression getQuery();
   }
 
   @Value.Immutable
   interface QueryInputParameter extends QueryInput {
     String getQueryId();
 
-    QueryExpression getQuery();
+    StoredQueryExpression getQuery();
 
     String getParameterName();
   }
@@ -98,7 +98,7 @@ public interface SearchQueriesHandler
   interface QueryInputStoredQueryCreateReplace extends QueryInput, WithDryRun {
     String getQueryId();
 
-    QueryExpression getQuery();
+    StoredQueryExpression getQuery();
 
     boolean getStrict();
   }

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/SingleQuery.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/SingleQuery.java
@@ -10,10 +10,8 @@ package de.ii.ogcapi.features.search.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Preconditions;
-import com.google.common.hash.Funnel;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -21,29 +19,17 @@ import org.immutables.value.Value;
 @JsonDeserialize(builder = ImmutableSingleQuery.Builder.class)
 public interface SingleQuery {
 
-  @SuppressWarnings("UnstableApiUsage")
-  Funnel<SingleQuery> FUNNEL =
-      (from, into) -> {
-        from.getCollections().forEach(s -> into.putString(s, StandardCharsets.UTF_8));
-        from.getFilter()
-            .forEach(
-                (name, filter) -> {
-                  into.putString(name, StandardCharsets.UTF_8);
-                });
-        from.getSortby().forEach(s -> into.putString(s, StandardCharsets.UTF_8));
-        from.getProperties().forEach(s -> into.putString(s, StandardCharsets.UTF_8));
-      };
-
   @JsonIgnore String SCHEMA_REF = "#/components/schemas/Query";
 
   List<String> getCollections(); // String or Parameter
 
-  Map<String, Object> getFilter();
+  Optional<Object> getFilter();
 
   List<String> getSortby(); // String or Parameter
 
   List<String> getProperties(); // String or Parameter
 
+  @JsonIgnore
   @Value.Check
   default void check() {
     Preconditions.checkState(

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/SingleQueryWithParameters.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/SingleQueryWithParameters.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.features.search.domain;
+
+import static de.ii.ogcapi.features.search.domain.StoredQueryExpression.PARAMETER;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Style(jdkOnly = true, deepImmutablesDetection = true, builder = "new")
+@JsonDeserialize(builder = ImmutableSingleQueryWithParameters.Builder.class)
+public interface SingleQueryWithParameters {
+
+  @JsonIgnore String SCHEMA_REF = "#/components/schemas/Query";
+
+  // If provided, it must be a list with a single string or parameter
+  List<JsonNode> getCollections();
+
+  // a CQL2 filter object
+  Optional<JsonNode> getFilter();
+
+  // List of string or parameter, or a parameter that is a string array
+  Optional<JsonNode> getSortby();
+
+  // List of string or parameter, or a parameter that is a string array
+  Optional<JsonNode> getProperties();
+
+  @JsonIgnore
+  @Value.Check
+  default void check() {
+    Preconditions.checkState(
+        !getCollections().isEmpty(), "Each query must have a collection. Found no collection.");
+    Preconditions.checkState(
+        getCollections().size() < 2,
+        "Each query must be for a single collection. Join queries are currently not supported. Found collections: %s.",
+        getCollections());
+    Preconditions.checkState(
+        getCollections().stream()
+            .allMatch(v -> v.isTextual() || (v.isObject() && v.has(PARAMETER))),
+        "Each collection must be a string or a parameter. Collections: %s.",
+        getCollections());
+    Preconditions.checkState(
+        getSortby().isEmpty()
+            || getSortby().filter(v -> v.isObject() && v.has(PARAMETER)).isPresent()
+            || getSortby().stream()
+                .allMatch(v -> v.isTextual() || (v.isObject() && v.has(PARAMETER))),
+        "Sortby must be a list of strings/parameters or a parameter that is a string array. Value: %s.",
+        getSortby());
+    Preconditions.checkState(
+        getProperties().isEmpty()
+            || getProperties().filter(v -> v.isObject() && v.has(PARAMETER)).isPresent()
+            || getProperties().stream()
+                .allMatch(v -> v.isTextual() || (v.isObject() && v.has(PARAMETER))),
+        "Properties must be a list of strings/parameters or a parameter that is a string array. Value: %s.",
+        getProperties());
+  }
+}

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/StoredQueryExpression.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/StoredQueryExpression.java
@@ -1,0 +1,725 @@
+/*
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.features.search.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.hash.Funnel;
+import de.ii.ogcapi.foundation.domain.QueryParameterSet;
+import de.ii.ogcapi.foundation.domain.SchemaValidator;
+import de.ii.xtraplatform.values.domain.StoredValue;
+import de.ii.xtraplatform.values.domain.ValueBuilder;
+import de.ii.xtraplatform.values.domain.annotations.FromValueStore;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.BooleanSchema;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.NumberSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.BadRequestException;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Style(jdkOnly = true, deepImmutablesDetection = true, builder = "new")
+@FromValueStore(type = "queries")
+@JsonDeserialize(builder = ImmutableStoredQueryExpression.Builder.class)
+@SuppressWarnings("PMD.TooManyMethods")
+public interface StoredQueryExpression extends StoredValue {
+
+  ObjectMapper MAPPER =
+      new ObjectMapper()
+          .registerModule(new Jdk8Module())
+          .registerModule(new GuavaModule())
+          .configure(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY, true)
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  @SuppressWarnings("UnstableApiUsage")
+  Funnel<StoredQueryExpression> FUNNEL =
+      (from, into) -> {
+        try {
+          into.putString(MAPPER.writeValueAsString(from.asNode()), StandardCharsets.UTF_8);
+        } catch (JsonProcessingException ignore) {
+          // ignore
+          into.putInt(from.hashCode());
+        }
+      };
+
+  String SCHEMA_REF = "#/components/schemas/StoredQueryExpression";
+  String REF = "$ref";
+  String PARAMETER = "$parameter";
+
+  abstract class Builder implements ValueBuilder<StoredQueryExpression> {}
+
+  static StoredQueryExpression of(InputStream requestBody) throws IOException {
+    return MAPPER.readValue(requestBody, StoredQueryExpression.class);
+  }
+
+  String getId();
+
+  Optional<String> getTitle();
+
+  Optional<String> getDescription();
+
+  List<SingleQueryWithParameters> getQueries();
+
+  // If provided, it must be a list with a single string or parameter
+  List<JsonNode> getCollections();
+
+  // CQL2 filter object
+  Optional<JsonNode> getFilter();
+
+  // CRS URI or a parameter
+  Optional<JsonNode> getFilterCrs();
+
+  // FilterOperator or parameter
+  Optional<JsonNode> getFilterOperator();
+
+  // List of string or parameter, or a parameter that is a string array
+  Optional<JsonNode> getSortby();
+
+  // List of string or parameter, or a parameter that is a string array
+  Optional<JsonNode> getProperties();
+
+  // CRS URI or a parameter
+  Optional<JsonNode> getCrs();
+
+  // CRS URI or a parameter
+  Optional<JsonNode> getVerticalCrs();
+
+  // Double or Parameter
+  Optional<JsonNode> getMaxAllowableOffset();
+
+  // Integer or Parameter
+  Optional<JsonNode> getLimit();
+
+  // should not be provided in a stored query as it will be set when executing the query
+  Optional<Integer> getOffset();
+
+  // List of string or parameter, or a parameter that is a string array
+  Optional<JsonNode> getProfiles();
+
+  // If provided, it must be an object with schemas as the values
+  Map<String, JsonNode> getParameters();
+
+  @JsonIgnore
+  @Value.Check
+  default void check() {
+    Preconditions.checkState(
+        getQueries().isEmpty() && getCollections().size() == 1
+            || !getQueries().isEmpty() && getCollections().isEmpty(),
+        "Either one or more queries must be provided or a single collection. Query: %s. Collections: %s.",
+        getQueries(),
+        getCollections());
+    Preconditions.checkState(
+        getCollections().stream()
+            .allMatch(v -> v.isTextual() || (v.isObject() && v.has(PARAMETER))),
+        "Each collection must be a string or a parameter. Collections: %s.",
+        getCollections());
+    Preconditions.checkState(
+        getFilterOperator().isEmpty()
+            || getFilterOperator()
+                .filter(v -> v.isTextual() || (v.isObject() && v.has(PARAMETER)))
+                .isPresent(),
+        "The filter operator must be a string or a parameter. Filter operator: %s.",
+        getFilterOperator());
+    Preconditions.checkState(
+        getFilterCrs().isEmpty()
+            || getFilterCrs()
+                .filter(v -> v.isTextual() || (v.isObject() && v.has(PARAMETER)))
+                .isPresent(),
+        "The filter CRS must be a string or a parameter. Filter CRS: %s.",
+        getFilterCrs());
+    Preconditions.checkState(
+        getCrs().isEmpty()
+            || getCrs()
+                .filter(v -> v.isTextual() || (v.isObject() && v.has(PARAMETER)))
+                .isPresent(),
+        "The CRS must be a string or a parameter. CRS: %s.",
+        getCrs());
+    Preconditions.checkState(
+        getVerticalCrs().isEmpty()
+            || getVerticalCrs()
+                .filter(v -> v.isTextual() || (v.isObject() && v.has(PARAMETER)))
+                .isPresent(),
+        "The vertical CRS must be a string or a parameter. Vertical CRS: %s.",
+        getVerticalCrs());
+    Preconditions.checkState(
+        getLimit().isEmpty()
+            || getLimit().filter(v -> v.isInt() || (v.isObject() && v.has(PARAMETER))).isPresent(),
+        "The limit must be an integer or a parameter. Limit: %s.",
+        getLimit());
+    Preconditions.checkState(
+        getMaxAllowableOffset().isEmpty()
+            || getMaxAllowableOffset()
+                .filter(v -> v.isDouble() || (v.isObject() && v.has(PARAMETER)))
+                .isPresent(),
+        "The maxAllowableOffset must be a double or a parameter. MaxAllowableOffset: %s.",
+        getMaxAllowableOffset());
+    Preconditions.checkState(
+        getSortby().isEmpty()
+            || getSortby().filter(v -> v.isObject() && v.has(PARAMETER)).isPresent()
+            || getSortby()
+                .filter(
+                    v ->
+                        v.isArray()
+                            && StreamSupport.stream(v.spliterator(), false)
+                                .allMatch(
+                                    v2 -> v2.isTextual() || (v2.isObject() && v2.has(PARAMETER))))
+                .isPresent(),
+        "Sortby must be a list of strings/parameters or a parameter that is a string array. Value: %s.",
+        getSortby());
+    Preconditions.checkState(
+        getProperties().isEmpty()
+            || getProperties().filter(v -> v.isObject() && v.has(PARAMETER)).isPresent()
+            || getProperties()
+                .filter(
+                    v ->
+                        v.isArray()
+                            && StreamSupport.stream(v.spliterator(), false)
+                                .allMatch(
+                                    v2 -> v2.isTextual() || (v2.isObject() && v2.has(PARAMETER))))
+                .isPresent(),
+        "Properties must be a list of strings/parameters or a parameter that is a string array. Value: %s.",
+        getProperties());
+    Preconditions.checkState(
+        getProfiles().isEmpty()
+            || getProfiles().filter(v -> v.isObject() && v.has(PARAMETER)).isPresent()
+            || getProfiles()
+                .filter(
+                    v ->
+                        v.isArray()
+                            && StreamSupport.stream(v.spliterator(), false)
+                                .allMatch(
+                                    v2 -> v2.isTextual() || (v2.isObject() && v2.has(PARAMETER))))
+                .isPresent(),
+        "Profiles must be a list of strings/parameters or a parameter that is a string array. Value: %s.",
+        getProfiles());
+  }
+
+  @JsonIgnore
+  @Value.Derived
+  @Value.Auxiliary
+  default ObjectNode asNode() {
+    return MAPPER.valueToTree(this);
+  }
+
+  @JsonIgnore
+  @Value.Derived
+  @Value.Auxiliary
+  default boolean hasParameters() {
+    return !getParameterNames().isEmpty();
+  }
+
+  @JsonIgnore
+  @Value.Derived
+  @Value.Auxiliary
+  default Set<String> getParameterNames() {
+    return ImmutableSet.<String>builder().addAll(getParameterNamesFromJson(asNode())).build();
+  }
+
+  @JsonIgnore
+  @Value.Derived
+  @Value.Auxiliary
+  default Map<String, JsonNode> getParametersAsNodes() {
+    return getParametersFromJson(asNode(), getParameters());
+  }
+
+  @JsonIgnore
+  @Value.Derived
+  @Value.Auxiliary
+  default Map<String, Schema<?>> getParametersWithOpenApiSchema() {
+    ImmutableMap.Builder<String, Schema<?>> paramBuilder = ImmutableMap.builder();
+    getParametersAsNodes().forEach((key, value) -> paramBuilder.put(key, deriveSchema(value)));
+    return paramBuilder.build();
+  }
+
+  default QueryExpression resolveParameters(
+      QueryParameterSet queryParameterSet, SchemaValidator schemaValidator) {
+    ObjectNode query = asNode();
+
+    Map<String, JsonNode> params = getParametersAsNodes();
+    if (!params.isEmpty()) {
+      ImmutableMap.Builder<String, JsonNode> builder = ImmutableMap.builder();
+      JsonNode valueAsNode;
+      for (Map.Entry<String, JsonNode> entry : params.entrySet()) {
+
+        // get the JSON Schema of the parameter as a string for validation
+        String schemaAsString;
+        try {
+          schemaAsString = MAPPER.writeValueAsString(entry.getValue());
+        } catch (JsonProcessingException e) {
+          throw new IllegalStateException(
+              String.format(
+                  "Could not read the schema of parameter '%s' in a query.", entry.getKey()),
+              e);
+        }
+
+        // get value as node (for the result)
+        if (queryParameterSet.getTypedValues().containsKey(entry.getKey())) {
+          valueAsNode = (JsonNode) queryParameterSet.getTypedValues().get(entry.getKey());
+        } else {
+          // no value provided, use default or throw an exception
+          valueAsNode = useDefault(entry);
+        }
+
+        validateParameter(schemaValidator, valueAsNode, entry, schemaAsString);
+        builder.put(entry.getKey(), valueAsNode);
+      }
+
+      replaceParameters(query, builder.build());
+    }
+
+    if (query.get("sortby").isNull()) {
+      query.putArray("sortby");
+    }
+    if (query.get("properties").isNull()) {
+      query.putArray("properties");
+    }
+    if (query.get("profiles").isNull()) {
+      query.putArray("profiles");
+    }
+    if (query.get("queries").isNull()) {
+      query.putArray("queries");
+    } else {
+      for (Iterator<JsonNode> it = query.get("queries").elements(); it.hasNext(); ) {
+        ObjectNode singleQuery = (ObjectNode) it.next();
+        if (singleQuery.get("sortby").isNull()) {
+          singleQuery.putArray("sortby");
+        }
+        if (singleQuery.get("properties").isNull()) {
+          singleQuery.putArray("properties");
+        }
+      }
+    }
+
+    query.remove("parameters");
+
+    try {
+      return MAPPER.treeToValue(query, QueryExpression.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private JsonNode useDefault(Entry<String, JsonNode> entry) {
+    JsonNode valueAsNode;
+    valueAsNode = entry.getValue().get("default");
+    if (Objects.isNull(valueAsNode) || valueAsNode.isNull()) {
+      throw new BadRequestException(
+          String.format("No value provided for parameter '%s'.", entry.getKey()));
+    }
+    return valueAsNode;
+  }
+
+  private void validateParameter(
+      SchemaValidator schemaValidator,
+      JsonNode valueAsNode,
+      Entry<String, JsonNode> entry,
+      String schemaAsString) {
+    final String value;
+    try {
+      // convert to string for validation
+      value = MAPPER.writeValueAsString(valueAsNode);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(
+          String.format(
+              "The JSON value derived for parameter '%s' could not be converted to a string value for validation.",
+              entry.getKey()),
+          e);
+    }
+    // validate parameter
+    try {
+      schemaValidator
+          .validate(schemaAsString, value)
+          .ifPresent(
+              error -> {
+                throw new BadRequestException(
+                    String.format(
+                        "Parameter '%s' is invalid, the value '%s' does not conform to the schema '%s'. Reason: %s",
+                        entry.getKey(), value, schemaAsString, error));
+              });
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          String.format(
+              "Could not validate value '%s' of parameter '%s' against its schema '%s'",
+              value, entry.getKey(), schemaAsString),
+          e);
+    }
+  }
+
+  private Schema<?> deriveSchema(@NotNull JsonNode schemaNode) {
+    if (!schemaNode.isObject()) {
+      throw new IllegalArgumentException(
+          String.format("Found a parameter without a schema object. Found %s", schemaNode));
+    }
+
+    Schema<?> schema;
+    if (Objects.nonNull(schemaNode.get(REF))) {
+      schema = new ObjectSchema();
+      schema.$ref(schemaNode.get(REF).asText());
+    } else if (Objects.isNull(schemaNode.get("type"))) {
+      throw new IllegalArgumentException(
+          "Found a parameter without a 'type' member in the schema.");
+    } else {
+      schema =
+          switch (schemaNode.get("type").asText()) {
+            case "object" -> getObjectSchema(schemaNode);
+            case "array" -> getArraySchema(schemaNode);
+            case "string" -> getStringSchema(schemaNode);
+            case "number" -> getNumberSchema(schemaNode);
+            case "integer" -> getIntegerSchema(schemaNode);
+            case "boolean" -> new BooleanSchema();
+            default -> throw new IllegalArgumentException(
+                String.format(
+                    "Found unsupported 'type'. Found: %s", schemaNode.get("type").asText()));
+          };
+    }
+    setMetadata(schemaNode, schema);
+    return schema;
+  }
+
+  private Schema<?> getObjectSchema(JsonNode schemaNode) {
+    ObjectSchema schema = new ObjectSchema();
+    ObjectNode properties = (ObjectNode) schemaNode.get("properties");
+    if (Objects.nonNull(properties)) {
+      JsonNode node = schemaNode.get("required");
+      if (Objects.nonNull(node)) {
+        Iterator<JsonNode> iter = node.elements();
+        while (iter.hasNext()) {
+          schema.addRequiredItem(iter.next().asText());
+        }
+      }
+      Iterator<Entry<String, JsonNode>> iter = properties.fields();
+      while (iter.hasNext()) {
+        Entry<String, JsonNode> entry = iter.next();
+        schema.addProperties(entry.getKey(), deriveSchema(entry.getValue()));
+      }
+      node = schemaNode.get("minProperties");
+      if (Objects.nonNull(node)) {
+        schema.minProperties(node.asInt());
+      }
+      node = schemaNode.get("maxProperties");
+      if (Objects.nonNull(node)) {
+        schema.maxProperties(node.asInt());
+      }
+    }
+    // see limitation, not supported: patternProperties, additionalProperties, allOf, oneOf
+    return schema;
+  }
+
+  private Schema<?> getArraySchema(JsonNode schemaNode) {
+    ArraySchema schema = new ArraySchema();
+    JsonNode node = schemaNode.get("items");
+    if (Objects.nonNull(node)) {
+      schema.items(deriveSchema(node));
+    }
+    node = schemaNode.get("minItems");
+    if (Objects.nonNull(node)) {
+      schema.minItems(node.asInt());
+    }
+    node = schemaNode.get("maxItems");
+    if (Objects.nonNull(node)) {
+      schema.maxItems(node.asInt());
+    }
+    node = schemaNode.get("uniqueObject");
+    if (Objects.nonNull(node)) {
+      schema.uniqueItems(node.asBoolean());
+    }
+    // see limitation, not supported: prefixItems, additionalItems, items:false
+    return schema;
+  }
+
+  private Schema<?> getStringSchema(JsonNode schemaNode) {
+    StringSchema schema = new StringSchema();
+    JsonNode node = schemaNode.get("format");
+    if (Objects.nonNull(node)) {
+      schema.format(node.asText());
+    }
+    node = schemaNode.get("minLength");
+    if (Objects.nonNull(node)) {
+      schema.minLength(node.asInt());
+    }
+    node = schemaNode.get("maxLength");
+    if (Objects.nonNull(node)) {
+      schema.maxLength(node.asInt());
+    }
+    node = schemaNode.get("pattern");
+    if (Objects.nonNull(node)) {
+      schema.pattern(node.asText());
+    }
+    JsonNode enums = schemaNode.get("enum");
+    if (Objects.nonNull(enums)) {
+      Iterator<JsonNode> iter = enums.elements();
+      while (iter.hasNext()) {
+        schema.addEnumItem(iter.next().asText());
+      }
+    }
+    return schema;
+  }
+
+  private Schema<?> getNumberSchema(JsonNode schemaNode) {
+    NumberSchema schema = new NumberSchema();
+    JsonNode node = schemaNode.get("multipleOf");
+    if (Objects.nonNull(node)) {
+      schema.multipleOf(node.decimalValue());
+    }
+    node = schemaNode.get("minimum");
+    if (Objects.nonNull(node)) {
+      schema.minimum(node.decimalValue());
+    }
+    node = schemaNode.get("exclusiveMinimum");
+    if (Objects.nonNull(node)) {
+      schema.minimum(node.decimalValue());
+      schema.exclusiveMinimum(true);
+    }
+    node = schemaNode.get("maximum");
+    if (Objects.nonNull(node)) {
+      schema.maximum(node.decimalValue());
+    }
+    node = schemaNode.get("exclusiveMaximum");
+    if (Objects.nonNull(node)) {
+      schema.maximum(node.decimalValue());
+      schema.exclusiveMaximum(true);
+    }
+    JsonNode enums = schemaNode.get("enum");
+    if (Objects.nonNull(enums)) {
+      Iterator<JsonNode> iter = enums.elements();
+      while (iter.hasNext()) {
+        schema.addEnumItem(iter.next().decimalValue());
+      }
+    }
+    return schema;
+  }
+
+  private Schema<?> getIntegerSchema(JsonNode schemaNode) {
+    IntegerSchema schema = new IntegerSchema();
+    JsonNode node = schemaNode.get("multipleOf");
+    if (Objects.nonNull(node)) {
+      schema.multipleOf(node.decimalValue());
+    }
+    node = schemaNode.get("minimum");
+    if (Objects.nonNull(node)) {
+      schema.minimum(node.decimalValue());
+    }
+    node = schemaNode.get("exclusiveMinimum");
+    if (Objects.nonNull(node)) {
+      schema.minimum(node.decimalValue());
+      schema.exclusiveMinimum(true);
+    }
+    node = schemaNode.get("maximum");
+    if (Objects.nonNull(node)) {
+      schema.maximum(node.decimalValue());
+    }
+    node = schemaNode.get("exclusiveMaximum");
+    if (Objects.nonNull(node)) {
+      schema.maximum(node.decimalValue());
+      schema.exclusiveMaximum(true);
+    }
+    JsonNode enums = schemaNode.get("enum");
+    if (Objects.nonNull(enums)) {
+      Iterator<JsonNode> iter = enums.elements();
+      while (iter.hasNext()) {
+        schema.addEnumItem(iter.next().decimalValue());
+      }
+    }
+    return schema;
+  }
+
+  private void setMetadata(JsonNode schemaNode, Schema<?> schema) {
+    JsonNode node = schemaNode.get("title");
+    if (Objects.nonNull(node)) {
+      schema.title(node.asText());
+    }
+    node = schemaNode.get("description");
+    if (Objects.nonNull(node)) {
+      schema.description(node.asText());
+    }
+    node = schemaNode.get("example");
+    if (Objects.nonNull(node)) {
+      try {
+        schema.example(MAPPER.treeToValue(node, Object.class));
+      } catch (JsonProcessingException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+    node = schemaNode.get("default");
+    if (Objects.nonNull(node)) {
+      try {
+        schema.setDefault(MAPPER.treeToValue(node, Object.class));
+      } catch (JsonProcessingException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+  }
+
+  private boolean isParameterNode(JsonNode node) {
+    return Objects.nonNull(node) && node.isObject() && Objects.nonNull(node.get(PARAMETER));
+  }
+
+  private String getParameterName(JsonNode valueNode) {
+    if (Objects.nonNull(valueNode) && valueNode.isObject()) {
+      if (valueNode.fields().hasNext()) {
+        Entry<String, JsonNode> firstMember = valueNode.fields().next();
+        if (REF.equals(firstMember.getKey())) {
+          if (firstMember.getValue().isTextual()
+              && firstMember.getValue().textValue().startsWith("#/parameters/")) {
+            return firstMember.getValue().textValue().substring(13);
+          } else {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Found '$ref' object where the value is not a JSON Reference to a member in '#/parameters'. Found: %s",
+                    firstMember.getValue()));
+          }
+        } else {
+          return firstMember.getKey();
+        }
+      } else {
+        throw new IllegalArgumentException(
+            "Found empty '$parameter' object. Either the JSON Schema of the parameter must be provided or a JSON Reference to the top-level 'parameters' member.");
+      }
+    }
+
+    throw new IllegalArgumentException(
+        String.format(
+            "Illegal value of a '$parameter' key. The value must be either a local JSON Reference to a parameter defined in the 'parameters' member or a JSON Schema object. Found: %s",
+            valueNode));
+  }
+
+  private void replaceParameters(JsonNode node, Map<String, JsonNode> params) {
+    if (Objects.nonNull(node)) {
+      if (node.isArray()) {
+        ArrayNode arrayNode = (ArrayNode) node;
+        for (int i = 0; i < arrayNode.size(); i++) {
+          if (isParameterNode(arrayNode.get(i))) {
+            arrayNode.set(i, params.get(getParameterName(arrayNode.get(i).get(PARAMETER))));
+          } else {
+            replaceParameters(arrayNode.get(i), params);
+          }
+        }
+      } else if (node.isObject()) {
+        ObjectNode objectNode = (ObjectNode) node;
+        Iterator<Entry<String, JsonNode>> iter = objectNode.fields();
+        while (iter.hasNext()) {
+          Map.Entry<String, JsonNode> entry = iter.next();
+          if (isParameterNode(entry.getValue())) {
+            objectNode.set(
+                entry.getKey(), params.get(getParameterName(entry.getValue().get(PARAMETER))));
+          } else {
+            replaceParameters(entry.getValue(), params);
+          }
+        }
+      } else if (!node.isNull() && !node.isValueNode()) {
+        throw new IllegalStateException(
+            String.format("Support for schema type %s not implemented.", node.getNodeType()));
+      }
+    }
+  }
+
+  private Map<String, JsonNode> getParametersFromJson(
+      JsonNode node, Map<String, JsonNode> predefinedParameters) {
+    if (Objects.isNull(node)) {
+      return ImmutableMap.of();
+    }
+
+    Map<String, JsonNode> params = ImmutableMap.of();
+    if (node.isArray()) {
+      ArrayNode arrayNode = (ArrayNode) node;
+      for (int i = 0; i < arrayNode.size(); i++) {
+        params = mergeMaps(params, getParametersFromJson(arrayNode.get(i), predefinedParameters));
+      }
+    } else if (node.isObject()) {
+      JsonNode param = node.get(PARAMETER);
+      if (Objects.isNull(param)) {
+        ObjectNode objectNode = (ObjectNode) node;
+        Iterator<Map.Entry<String, JsonNode>> iter = objectNode.fields();
+        while (iter.hasNext()) {
+          Map.Entry<String, JsonNode> entry = iter.next();
+          params = mergeMaps(params, getParametersFromJson(entry.getValue(), predefinedParameters));
+        }
+      } else if (param.isObject()) {
+        String name = getParameterName(param);
+        // ignore multiple definitions of the same parameter
+        if (!params.containsKey(name)) {
+          Map.Entry<String, JsonNode> entry = param.fields().next();
+          if (REF.equals(entry.getKey())) {
+            if (predefinedParameters.containsKey(name)) {
+              params = mergeMaps(params, ImmutableMap.of(name, predefinedParameters.get(name)));
+            } else {
+              throw new IllegalArgumentException(
+                  String.format(
+                      "Undefined parameter '%s' referenced in query.", param.textValue()));
+            }
+          } else {
+            params = mergeMaps(params, ImmutableMap.of(entry.getKey(), entry.getValue()));
+          }
+        }
+      }
+    }
+    return params;
+  }
+
+  private Map<String, JsonNode> mergeMaps(
+      Map<String, JsonNode> current, Map<String, JsonNode> additional) {
+    return Stream.of(current, additional)
+        .flatMap(map -> map.entrySet().stream())
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue, (n1, n2) -> n1));
+  }
+
+  private Set<String> getParameterNamesFromJson(JsonNode node) {
+    if (Objects.isNull(node)) {
+      return ImmutableSet.of();
+    }
+
+    ImmutableSet.Builder<String> builder = new ImmutableSet.Builder<>();
+    if (node.isArray()) {
+      ArrayNode arrayNode = (ArrayNode) node;
+      for (int i = 0; i < arrayNode.size(); i++) {
+        builder.addAll(getParameterNamesFromJson(arrayNode.get(i)));
+      }
+    } else if (node.isObject()) {
+      JsonNode param = node.get(PARAMETER);
+      if (Objects.isNull(param)) {
+        ObjectNode objectNode = (ObjectNode) node;
+        Iterator<Map.Entry<String, JsonNode>> iter = objectNode.fields();
+        while (iter.hasNext()) {
+          Map.Entry<String, JsonNode> entry = iter.next();
+          builder.addAll(getParameterNamesFromJson(entry.getValue()));
+        }
+      } else if (param.isObject()) {
+        builder.add(getParameterName(param));
+      }
+    }
+    return builder.build();
+  }
+}

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/StoredQueryFormat.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/StoredQueryFormat.java
@@ -26,5 +26,6 @@ public interface StoredQueryFormat extends GenericFormatExtension {
    */
   String getFileExtension();
 
-  Object getEntity(QueryExpression query, OgcApiDataV2 apiData, ApiRequestContext requestContext);
+  Object getEntity(
+      StoredQueryExpression query, OgcApiDataV2 apiData, ApiRequestContext requestContext);
 }

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/StoredQueryRepository.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/StoredQueryRepository.java
@@ -52,7 +52,7 @@ public interface StoredQueryRepository extends Volatile2 {
    * @param apiData information about the API
    * @return the list of stored queries in this collection and links to API resources
    */
-  List<QueryExpression> getAll(OgcApiDataV2 apiData);
+  List<StoredQueryExpression> getAll(OgcApiDataV2 apiData);
 
   /**
    * fetches a stored query
@@ -61,7 +61,7 @@ public interface StoredQueryRepository extends Volatile2 {
    * @param queryId the identifier of the query in the query collection
    * @return the stored queriesheet, or throws an exception, if not available
    */
-  QueryExpression get(OgcApiDataV2 apiData, String queryId);
+  StoredQueryExpression get(OgcApiDataV2 apiData, String queryId);
 
   /**
    * determine, if a stored query is available
@@ -101,7 +101,7 @@ public interface StoredQueryRepository extends Volatile2 {
 
   Set<String> getIds(OgcApiDataV2 apiData);
 
-  void writeStoredQueryDocument(OgcApiDataV2 apiData, String queryId, QueryExpression query)
+  void writeStoredQueryDocument(OgcApiDataV2 apiData, String queryId, StoredQueryExpression query)
       throws IOException;
 
   void deleteStoredQuery(OgcApiDataV2 apiData, String queryId) throws IOException;


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [x] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

Currently, parameters are only supported in filter expressions in a stored query. Parameters are also useful in other members of a query expression, e.g. the CRS information, the limit value or the profiles to apply.

This commit supports the use of parameters in all members of the query expression of a stored query, except "id", "title", "description", and "offset".

A new immutable `StoredQueryExpression` is introduced that supports parameter objects in the values of the query expression of a stored query. These instances are what is stored as values. The `QueryExpression` is simplified to remove all support for parameters.

Example of the use of parameters in "crs" and "profiles":

```
    ...,
    "crs": {
        "$parameter": {
            "crs": {
                "title": "Koordinatenreferenzsystem",
                "description": "Koordinatenreferenzsystem in dem Geometrien zurückgegeben werden sollen.",
                "type": "string",
                "enum": [
                    "http://www.opengis.net/def/crs/EPSG/0/25832" ,
                    "http://www.opengis.net/def/crs/EPSG/0/4258"  ,
                    "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
                ],
                "default": "rhttp://[www.opengis.net/def/crs/EPSG/0/25832](http://www.opengis.net/def/crs/EPSG/0/25832)"
            }
        }
    },
    "profiles": [
        {
            "$parameter": {
                "profil-rel": {
                    "title": "Anzuwendendes Profil für Relationen",
                    "description": "Das Profil für die Darstellung von Objektreferenzen, das angewendet werden soll. `rel-as-key` bedeutet, dass die Objektreferenzen als Fremdschlüssel des referenzierten Objekts dargestellt werden; bei `rel-as-uri` wird die HTTP-URI des referenzierten Objekts verwendet; bei `rel-as-link` wird ein Link-Objekt verwendet.",
                    "type": "string",
                    "enum": ["rel-as-key", "rel-as-uri", "rel-as-link"],
                    "default": "rel-as-uri"
                }
            }
        },
        {
            "$parameter": {
                "profil-val": {
                    "title": "Anzuwendendes Profil für Codelisten",
                    "description": "Das Profil für die Darstellung von Werten aus Codelisten, das angewendet werden soll. Bei `val-as-code` werden die Werte als  dargestellt; bei `val-as-title` werden die Werte als lesbare Texte dargestellt.",
                    "type": "string",
                    "enum": ["val-as-code", "val-as-title"],
                    "default": "val-as-code"
                }
            }
        }
    ],
    ...
```