### PR TITLE
Reduce number of glTF drawing calls

### DIFF
--- a/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/app/FeatureEncoderGltf.java
+++ b/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/app/FeatureEncoderGltf.java
@@ -194,8 +194,8 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
             addMultiPolygons(
                 builder, transformationContext, state, feature, fid, surfaces, withSurfaceType);
         if (added) {
-          // flush node, if the indices count is close to the maximum value of an unsigned short
-          if (state.getIndices().size() > (Short.MAX_VALUE - Short.MIN_VALUE) * 0.9) {
+          if (state.getIndices().size() > Integer.MAX_VALUE * 0.9) {
+            // flush node, if the indices count is close to the maximum value
             flushNode(builder, transformationContext, state);
             int nextNodeId = state.getNextNodeId();
             nodes.add(nextNodeId++);
@@ -813,7 +813,6 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
     } else if (indices.size() <= Short.MAX_VALUE - Short.MIN_VALUE) {
       componentType = UNSIGNED_SHORT;
     } else {
-      // UNSIGNED_INT is not allowed
       componentType = UNSIGNED_INT;
     }
 

--- a/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/app/StateGltf.java
+++ b/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/app/StateGltf.java
@@ -8,7 +8,9 @@
 package de.ii.ogcapi.features.gltf.app;
 
 import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.immutables.value.Value;
 
@@ -21,13 +23,48 @@ public class StateGltf {
   }
 
   @Value.Default
-  Map<String, Integer> getCurrentBufferViewOffsets() {
-    return new HashMap<>();
+  int getNextFeatureId() {
+    return 0;
   }
 
   @Value.Default
-  int getNextFeatureId() {
+  List<Double> getVertices() {
+    return new ArrayList<>();
+  }
+
+  @Value.Default
+  List<Double> getNormals() {
+    return new ArrayList<>();
+  }
+
+  @Value.Default
+  List<Integer> getIndices() {
+    return new ArrayList<>();
+  }
+
+  @Value.Default
+  List<Integer> getFeatureIds() {
+    return new ArrayList<>();
+  }
+
+  @Value.Default
+  List<Integer> getOutline() {
+    return new ArrayList<>();
+  }
+
+  @Value.Default
+  int getIndexCount() {
     return 0;
+  }
+
+  @Value.Default
+  int getSurfaceCount() {
+    return 0;
+  }
+
+  @Value.Default
+  Map<String, Integer> getCurrentBufferViewOffsets() {
+    return new HashMap<>();
   }
 
   @Value.Default


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

Closes #1358.

These changes join nodes/meshes/primitives to significantly reduce the number of drawing calls.

Additional improvements could be implemented, e.g., reordering of triangles for improved GPU performance or transmission size, compression, simplification of triangles, etc.

