### PR TITLE
MapLibre popups: render HTTP URLs as clickable links

### DIFF
--- a/ogcapi-stable/ogcapi-html/src/main/javascript/src/components/MapLibre/Configuration/popup.js
+++ b/ogcapi-stable/ogcapi-html/src/main/javascript/src/components/MapLibre/Configuration/popup.js
@@ -47,7 +47,11 @@ const getPopupContent = (e) => {
   Object.keys(e.features[0].properties)
     .sort()
     .forEach((prop) => {
-      description += `<tr><td title="${prop}" class="pr-4"><strong>${prop}</strong></td><td title="${e.features[0].properties[prop]}">${e.features[0].properties[prop]}</td></tr>`;
+      let val = e.features[0].properties[prop];
+      if (typeof val === 'string' && /^https?:\/\/[^\s]+$/.test(val)) {
+        val = `<a href="${val}" target="_blank">${val}</a>`;
+      }
+      description += `<tr><td title="${prop}" class="pr-4"><strong>${prop}</strong></td><td title="${e.features[0].properties[prop]}">${val}</td></tr>`;
     });
 
   description += "</table>";


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

Closes #1367.

The HTML view of features also maps URLs of PNG/JPEG images to `<img>` elements to directly display the image. I decided not to include this behavior in the popup since images may be too large for a popup.
