### PR TITLE
Improve 3D Tiles

### DIFF
--- a/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/app/FeatureEncoderGltf.java
+++ b/ogcapi-draft/ogcapi-features-gltf/src/main/java/de/ii/ogcapi/features/gltf/app/FeatureEncoderGltf.java
@@ -681,6 +681,11 @@ public class FeatureEncoderGltf extends FeatureObjectEncoder<PropertyGltf, Featu
     Map<String, ByteArrayOutputStream> buffers = state.getBuffers();
 
     for (MeshSurface surface : surfaces.getMeshSurfaces()) {
+      if (surface.getSurfaceType().filter(t -> t.toLowerCase().startsWith("closure")).isPresent()) {
+        // closure surface are virtual surfaces that are not relevant for visualization; skip them
+        continue;
+      }
+
       TriangleMesh triangleMesh =
           TriangleMesh.of(
               surface.getGeometry(),


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

This Pull Request includes the following improvements or bugfixes: 

- 3D Tiles: A building that crosses tile boundaries has been included in all tiles that it intersects, which increases the overall payload and results in rendering artefacts in those buildings. A building is now included in only one tile - the northwestern-most tile that the building intersects.
- glTF: The earcut4j library sometimes creates incorrect triangulation results (e.g., triangles are created that go beyond the polygon). The JTS triangulation seems to produce better results. It is a bit slower and is not always able to compute the triangles. The changed code first tries the `ConstrainedDelaunayTriangulator` from JTS and if that fails, earcut4j is used.
- glTF: In addition, the orientation (ccw or cw) was sometimes not detected/applied correctly.
- glTF: Closure surfaces are virtual surfaces. They are added when a closed surface is needed, e.g., to compute volumes. They should be ignored in visualizations, so they are skipped in the glTF representation.
