### PR TITLE
GeoJSON/JSON-FG: handle unsupported geometries

### DIFF
--- a/gradle/layers.versions.toml
+++ b/gradle/layers.versions.toml
@@ -1,5 +1,5 @@
 [versions]
 xtraplatform-core    = '6.4.0-SNAPSHOT'
 xtraplatform-native  = '2.5.0'
-xtraplatform-spatial = '7.4.0-SNAPSHOT'
+xtraplatform-spatial = '7.4.0-issue-1413-SNAPSHOT'
 

--- a/gradle/layers.versions.toml
+++ b/gradle/layers.versions.toml
@@ -1,5 +1,5 @@
 [versions]
 xtraplatform-core    = '6.4.0-SNAPSHOT'
 xtraplatform-native  = '2.5.0'
-xtraplatform-spatial = '7.4.0-issue-1413-SNAPSHOT'
+xtraplatform-spatial = '7.4.0-SNAPSHOT'
 

--- a/ogcapi-draft/ogcapi-features-jsonfg/src/main/java/de/ii/ogcapi/features/jsonfg/domain/JsonFgGeometryType.java
+++ b/ogcapi-draft/ogcapi-features-jsonfg/src/main/java/de/ii/ogcapi/features/jsonfg/domain/JsonFgGeometryType.java
@@ -18,8 +18,7 @@ public enum JsonFgGeometryType {
   POLYGON("Polygon", SimpleFeatureGeometry.POLYGON, 2),
   MULTI_POLYGON("MultiPolygon", SimpleFeatureGeometry.MULTI_POLYGON, 2),
   POLYHEDRON("Polyhedron", SimpleFeatureGeometry.MULTI_POLYGON, 3, true, true),
-  GEOMETRY_COLLECTION("GeometryCollection", SimpleFeatureGeometry.NONE, null),
-  GENERIC("", SimpleFeatureGeometry.NONE, null),
+  GEOMETRY_COLLECTION("GeometryCollection", SimpleFeatureGeometry.GEOMETRY_COLLECTION, null),
   NONE("", SimpleFeatureGeometry.NONE, null);
 
   private final String stringRepresentation;
@@ -97,5 +96,9 @@ public enum JsonFgGeometryType {
 
   public boolean isValid() {
     return this != NONE;
+  }
+
+  public boolean isSupported() {
+    return isValid() && this != GEOMETRY_COLLECTION;
   }
 }


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

In the writers for "geometry" and "place" detect unsupported geometries. Write a `null` geometry instead and add a log for the first instance of an unsupported geometry type.

JSON-FG geometry types: Remove GENERIC (unused), map GEOMETRY_COLLECTION and add new method `isSupported()`.

Depends on https://github.com/ldproxy/xtraplatform-spatial/pull/363

Closes #1413

