### PR TITLE
Transactions: configurable per-transaction setup and pre-commit hooks

### DIFF
--- a/gradle/layers.versions.toml
+++ b/gradle/layers.versions.toml
@@ -1,5 +1,5 @@
 [versions]
 xtraplatform-core    = '7.0.0-SNAPSHOT'
 xtraplatform-native  = '2.6.0-SNAPSHOT'
-xtraplatform-spatial = '8.0.0-SNAPSHOT'
+xtraplatform-spatial = '8.0.0-transaction-lifecycle-hooks-SNAPSHOT'
 

--- a/gradle/layers.versions.toml
+++ b/gradle/layers.versions.toml
@@ -1,5 +1,5 @@
 [versions]
 xtraplatform-core    = '7.0.0-SNAPSHOT'
 xtraplatform-native  = '2.6.0-SNAPSHOT'
-xtraplatform-spatial = '8.0.0-transaction-lifecycle-hooks-SNAPSHOT'
+xtraplatform-spatial = '8.0.0-SNAPSHOT'
 

--- a/ogcapi-draft/ogcapi-transactions/build.gradle
+++ b/ogcapi-draft/ogcapi-transactions/build.gradle
@@ -1,7 +1,12 @@
-maturity = 'CANDIDATE'
+maturity = 'PROPOSAL'
 maintenance = 'NONE'
 description = 'Atomic and batch transactions over multiple feature collections.'
 descriptionDe = 'Atomare und gestapelte Transaktionen über mehrere Objektarten.'
+
+// Transaction hooks in the configuration are currently SQL statements. Once there is a better
+// understanding of the types of hooks/statements that are needed, the option should be changed
+// to declaration that can be mapped to SQL statements internally. The maturity level should only
+// be raised once this is implemented.
 
 dependencies {
     provided 'de.interactive_instruments:xtraplatform-auth'

--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/CommandHandlerTransactionsImpl.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/CommandHandlerTransactionsImpl.java
@@ -63,7 +63,6 @@ public class CommandHandlerTransactionsImpl extends AbstractVolatileComposed
   @Override
   public Response processTransaction(
       QueryInputTransaction queryInput, ApiRequestContext requestContext) {
-    boolean validate = queryInput.getHandling() == HeaderPrefer.Handling.STRICT;
     Transaction transaction = null;
 
     try {
@@ -85,7 +84,7 @@ public class CommandHandlerTransactionsImpl extends AbstractVolatileComposed
                 requestContext.getApi(),
                 requestContext,
                 queryInput.getRequestCrs(),
-                validate,
+                queryInput.getHandling(),
                 queryInput.getMutationDatetime());
         transaction = null;
       } catch (IllegalArgumentException e) {
@@ -195,7 +194,7 @@ public class CommandHandlerTransactionsImpl extends AbstractVolatileComposed
     int status = (atomic && failed) ? 422 : 200;
     String preferenceApplied = preferenceApplied(ret, handling);
 
-    if (ret == HeaderPrefer.Return.NONE && !failed) {
+    if (ret == HeaderPrefer.Return.NONE && !failed && result.getWarnings().isEmpty()) {
       return Response.noContent().header("Preference-Applied", preferenceApplied).build();
     }
 
@@ -255,6 +254,10 @@ public class CommandHandlerTransactionsImpl extends AbstractVolatileComposed
 
     if (!exceptions.isEmpty()) {
       body.set("exceptions", exceptions);
+    }
+    if (!result.getWarnings().isEmpty()) {
+      ArrayNode warnings = body.putArray("warnings");
+      result.getWarnings().forEach(warnings::add);
     }
     return body;
   }

--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/TransactionExecutorImpl.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/TransactionExecutorImpl.java
@@ -26,6 +26,7 @@ import de.ii.ogcapi.foundation.domain.AliasConfiguration;
 import de.ii.ogcapi.foundation.domain.ApiRequestContext;
 import de.ii.ogcapi.foundation.domain.ExtensionRegistry;
 import de.ii.ogcapi.foundation.domain.FeatureTypeConfigurationOgcApi;
+import de.ii.ogcapi.foundation.domain.HeaderPrefer;
 import de.ii.ogcapi.foundation.domain.OgcApi;
 import de.ii.ogcapi.foundation.domain.OgcApiDataV2;
 import de.ii.ogcapi.foundation.domain.Profile;
@@ -39,6 +40,7 @@ import de.ii.ogcapi.transactions.domain.InsertItem;
 import de.ii.ogcapi.transactions.domain.MutationStrategy;
 import de.ii.ogcapi.transactions.domain.Transaction;
 import de.ii.ogcapi.transactions.domain.TransactionExecutor;
+import de.ii.ogcapi.transactions.domain.TransactionHooks;
 import de.ii.ogcapi.transactions.domain.TransactionsConfiguration;
 import de.ii.ogcapi.transactions.domain.TxAction;
 import de.ii.ogcapi.transactions.domain.TxActionType;
@@ -60,6 +62,7 @@ import de.ii.xtraplatform.crs.domain.CrsInfo;
 import de.ii.xtraplatform.crs.domain.EpsgCrs;
 import de.ii.xtraplatform.features.domain.FeatureChange;
 import de.ii.xtraplatform.features.domain.FeatureChanges;
+import de.ii.xtraplatform.features.domain.FeatureMutationHookException;
 import de.ii.xtraplatform.features.domain.FeatureProvider;
 import de.ii.xtraplatform.features.domain.FeatureSchema;
 import de.ii.xtraplatform.features.domain.FeatureTokenSource;
@@ -140,14 +143,40 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
       OgcApi api,
       ApiRequestContext requestContext,
       EpsgCrs requestCrs,
-      boolean validate,
+      HeaderPrefer.Handling handling,
       Optional<Instant> ogcMutationDatetime) {
     try (transaction) {
       return transaction.getSemantic() == TxSemantic.ATOMIC
           ? executeAtomic(
-              transaction, api, requestContext, requestCrs, validate, ogcMutationDatetime)
+              transaction, api, requestContext, requestCrs, handling, ogcMutationDatetime)
           : executeBatch(
-              transaction, api, requestContext, requestCrs, validate, ogcMutationDatetime);
+              transaction, api, requestContext, requestCrs, handling, ogcMutationDatetime);
+    }
+  }
+
+  /**
+   * The configured transaction-lifecycle hook statements (API-level) for this request's handling.
+   *
+   * @param preCommit {@code true} for the pre-commit hook, {@code false} for the setup hook
+   */
+  private static List<String> hookStatements(
+      OgcApi api, HeaderPrefer.Handling handling, boolean preCommit) {
+    TransactionsConfiguration cfg =
+        api.getData().getExtension(TransactionsConfiguration.class).orElse(null);
+    if (cfg == null) {
+      return List.of();
+    }
+    TransactionHooks hooks = preCommit ? cfg.getPreCommit() : cfg.getTransactionSetup();
+    return hooks == null ? List.of() : hooks.effective(handling);
+  }
+
+  /**
+   * When a hook statement fails, the warnings emitted by hook statements that ran before it are
+   * carried on the exception — recover them so they are still reported on the failure path.
+   */
+  private static void recoverHookWarnings(RuntimeException e, List<String> warnings) {
+    if (e instanceof FeatureMutationHookException hookEx) {
+      warnings.addAll(hookEx.getWarnings());
     }
   }
 
@@ -166,8 +195,13 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
       OgcApi api,
       ApiRequestContext ctx,
       EpsgCrs requestCrs,
-      boolean validate,
+      HeaderPrefer.Handling handling,
       Optional<Instant> ogcMutationDatetime) {
+    // handling=strict turns on per-payload schema validation before any write.
+    boolean validate = handling == HeaderPrefer.Handling.STRICT;
+    List<String> setup = hookStatements(api, handling, false);
+    List<String> preCommit = hookStatements(api, handling, true);
+    List<String> warnings = new ArrayList<>();
     // Single timestamp for the whole atomic transaction — every action shares it so versioned
     // strategies can reject same-feature chains under the no-backdating rule.
     Instant atomicScopeTimestamp = nowInstant();
@@ -195,9 +229,14 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
       }
       try {
         FeatureProvider provider = resolveProvider(api, action.getCollectionId());
-        Session session =
-            sessionsByProvider.computeIfAbsent(
-                provider.getId(), id -> openSession(provider, action.getCollectionId()));
+        Session session = sessionsByProvider.get(provider.getId());
+        if (session == null) {
+          session = openSession(provider, action.getCollectionId());
+          // Store before running setup so a setup failure still leaves the session in the map
+          // for the rollback/close paths below.
+          sessionsByProvider.put(provider.getId(), session);
+          warnings.addAll(session.execute(setup));
+        }
         results.add(
             runAction(
                 action,
@@ -224,6 +263,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
               .addAll(lastResult.getFeatureIds());
         }
       } catch (RuntimeException e) {
+        recoverHookWarnings(e, warnings);
         results.add(failed(action, e));
         firstError = e;
       }
@@ -232,12 +272,24 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
     boolean commitSucceeded = false;
     if (firstError == null) {
       try {
+        // Pre-commit hooks run on the still-open transaction; a raised error aborts the
+        // whole transaction, a warning lets it commit and is surfaced in the response.
+        for (Session s : sessionsByProvider.values()) {
+          warnings.addAll(s.execute(preCommit));
+        }
         sessionsByProvider.values().forEach(Session::commit);
         commitSucceeded = true;
       } catch (RuntimeException e) {
-        // commit failed — flip every recorded SUCCESS to FAILED with the commit error,
+        // pre-commit or commit failed — flip every recorded SUCCESS to FAILED with the error,
         // rollback whatever can still be rolled back
-        LOGGER.warn("Atomic transaction commit failed", e);
+        recoverHookWarnings(e, warnings);
+        if (e instanceof FeatureMutationHookException) {
+          // expected, configuration-driven rollback (a hook check fired) — reported to the
+          // client, so keep the log quiet and without a stack trace
+          LOGGER.debug("Pre-commit hook aborted the atomic transaction: {}", e.getMessage());
+        } else {
+          LOGGER.warn("Atomic transaction commit failed", e);
+        }
         rollbackQuietly(sessionsByProvider.values());
         results = flipSuccessesToFailed(results, e);
       }
@@ -253,6 +305,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
     return new ImmutableExecutionResult.Builder()
         .semantic(TxSemantic.ATOMIC)
         .actionResults(results)
+        .warnings(warnings)
         .build();
   }
 
@@ -263,8 +316,13 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
       OgcApi api,
       ApiRequestContext ctx,
       EpsgCrs requestCrs,
-      boolean validate,
+      HeaderPrefer.Handling handling,
       Optional<Instant> ogcMutationDatetime) {
+    // handling=strict turns on per-payload schema validation before any write.
+    boolean validate = handling == HeaderPrefer.Handling.STRICT;
+    List<String> setup = hookStatements(api, handling, false);
+    List<String> preCommit = hookStatements(api, handling, true);
+    List<String> warnings = new ArrayList<>();
     List<ActionResult> results = new ArrayList<>();
     // Reused across actions in a batch even though each action commits independently — keeps the
     // MutationStrategy lookup to one walk per (transaction, collectionId).
@@ -277,6 +335,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
       try {
         FeatureProvider provider = resolveProvider(api, action.getCollectionId());
         session = openSession(provider, action.getCollectionId());
+        warnings.addAll(session.execute(setup));
         // Batch semantics commit between actions, so each action sees a fresh committed
         // snapshot — no need to track touched ids across actions.
         // Per-action timestamp under batch semantics — each action's mutation is independent.
@@ -297,12 +356,19 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
                 true,
                 transaction.isWfs());
         if (r.getStatus() == ActionStatus.SUCCESS) {
+          // Pre-commit hooks run per action under batch semantics; a raised error fails just
+          // this action (caught below), a warning lets it commit and is surfaced.
+          warnings.addAll(session.execute(preCommit));
           session.commit();
         } else {
           session.rollback();
         }
         results.add(r);
       } catch (RuntimeException e) {
+        recoverHookWarnings(e, warnings);
+        if (e instanceof FeatureMutationHookException) {
+          LOGGER.debug("Pre-commit hook failed the batch action: {}", e.getMessage());
+        }
         if (session != null) {
           try {
             session.rollback();
@@ -327,6 +393,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
     return new ImmutableExecutionResult.Builder()
         .semantic(TxSemantic.BATCH)
         .actionResults(results)
+        .warnings(warnings)
         .build();
   }
 

--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/ExecutionResult.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/ExecutionResult.java
@@ -22,6 +22,13 @@ public interface ExecutionResult {
    */
   List<ActionResult> getActionResults();
 
+  /**
+   * Non-fatal warnings emitted by the configured transaction-lifecycle hooks (e.g. PostgreSQL
+   * {@code RAISE WARNING} / {@code RAISE NOTICE} from a setup or pre-commit statement). May be
+   * present on both successful and failed transactions.
+   */
+  List<String> getWarnings();
+
   /** Whether the transaction as a whole succeeded (no FAILED actions in atomic; any in batch). */
   @Value.Derived
   default boolean isSuccess() {

--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/TransactionExecutor.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/TransactionExecutor.java
@@ -8,6 +8,7 @@
 package de.ii.ogcapi.transactions.domain;
 
 import de.ii.ogcapi.foundation.domain.ApiRequestContext;
+import de.ii.ogcapi.foundation.domain.HeaderPrefer;
 import de.ii.ogcapi.foundation.domain.OgcApi;
 import de.ii.xtraplatform.base.domain.resiliency.Volatile2;
 import de.ii.xtraplatform.crs.domain.EpsgCrs;
@@ -23,12 +24,13 @@ public interface TransactionExecutor extends Volatile2 {
    * @param api target API
    * @param requestContext request context (used for collection/provider lookups)
    * @param requestCrs CRS to assume for feature payloads when not otherwise specified
-   * @param validate when {@code true}, each insert / replace payload is validated against its
-   *     target feature type's schema (via {@code FeatureFormatExtension.validate}) before any
-   *     provider write. Set by the endpoint when the client sends {@code Prefer: handling=strict}.
-   *     Per-feature failures inside an atomic transaction abort the transaction; failures inside a
-   *     batch transaction skip the offending item and surface it through {@link
-   *     ActionResult#getFailedFeatureIds()} / {@link ActionResult#getFailedFeaturePayloads()}.
+   * @param handling the request's {@code Prefer: handling} preference. {@code STRICT} turns on
+   *     payload validation against each target feature type's schema (via {@code
+   *     FeatureFormatExtension.validate}) before any provider write — per-feature failures inside
+   *     an atomic transaction abort the transaction, failures inside a batch transaction skip the
+   *     offending item and surface it through {@link ActionResult#getFailedFeatureIds()} / {@link
+   *     ActionResult#getFailedFeaturePayloads()}. It also selects which transaction-lifecycle hook
+   *     statements run (see {@code TransactionsConfiguration}).
    * @param ogcMutationDatetime parsed {@code OGC-Mutation-Datetime} request header, if supplied —
    *     used by versioned strategies in {@code client} mutation-time mode when an action carries no
    *     body-side primary-interval-start value
@@ -39,6 +41,6 @@ public interface TransactionExecutor extends Volatile2 {
       OgcApi api,
       ApiRequestContext requestContext,
       EpsgCrs requestCrs,
-      boolean validate,
+      HeaderPrefer.Handling handling,
       Optional<Instant> ogcMutationDatetime);
 }

--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/TransactionHooks.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/TransactionHooks.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.transactions.domain;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.ImmutableList;
+import de.ii.ogcapi.foundation.domain.HeaderPrefer;
+import java.util.List;
+import java.util.stream.Stream;
+import org.immutables.value.Value;
+
+/**
+ * Ordered SQL statements run at a point in a write transaction, selected by the request's `Prefer:
+ * handling` preference. The effective list for a request is the `always` statements followed by the
+ * `strict` or `lenient` statements, depending on the handling.
+ */
+@Value.Immutable
+@JsonDeserialize(builder = ImmutableTransactionHooks.Builder.class)
+public interface TransactionHooks {
+
+  /**
+   * @langEn Statements run regardless of the request's `Prefer: handling` preference, before any
+   *     handling-specific statements.
+   * @langDe Anweisungen, die unabhängig von der `Prefer: handling`-Präferenz der Anfrage ausgeführt
+   *     werden, vor den handling-spezifischen Anweisungen.
+   * @default []
+   * @since v4.8
+   */
+  List<String> getAlways();
+
+  /**
+   * @langEn Statements run in addition to `always` when the request is processed with `Prefer:
+   *     handling=strict`.
+   * @langDe Anweisungen, die zusätzlich zu `always` ausgeführt werden, wenn die Anfrage mit
+   *     `Prefer: handling=strict` verarbeitet wird.
+   * @default []
+   * @since v4.8
+   */
+  List<String> getStrict();
+
+  /**
+   * @langEn Statements run in addition to `always` when the request is processed with `Prefer:
+   *     handling=lenient` (the default handling).
+   * @langDe Anweisungen, die zusätzlich zu `always` ausgeführt werden, wenn die Anfrage mit
+   *     `Prefer: handling=lenient` verarbeitet wird (das Standard-Handling).
+   * @default []
+   * @since v4.8
+   */
+  List<String> getLenient();
+
+  /**
+   * The statements to run for the given handling: {@link #getAlways()} followed by the handling-
+   * specific list. Not a configuration option.
+   */
+  default List<String> effective(HeaderPrefer.Handling handling) {
+    return Stream.concat(
+            getAlways().stream(),
+            (handling == HeaderPrefer.Handling.STRICT ? getStrict() : getLenient()).stream())
+        .collect(ImmutableList.toImmutableList());
+  }
+}

--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/TransactionsConfiguration.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/TransactionsConfiguration.java
@@ -46,6 +46,26 @@ import org.immutables.value.Value;
  *           - tags               # VALUE_ARRAY
  *           - addresses          # OBJECT_ARRAY
  * ```
+ *
+ * Transaction-lifecycle hooks (PostgreSQL/PostGIS providers). Statements are selected by the
+ * request's `Prefer: handling` preference; a pre-commit error rolls the transaction back, a
+ * pre-commit warning lets it commit and is returned in the response:
+ *
+ * ```yaml
+ * - buildingBlock: TRANSACTIONS
+ *   transactionSetup:
+ *     always:
+ *       - SET LOCAL myapp.geometry_validation.enabled = true
+ *     strict:
+ *       - SET LOCAL myapp.geometry_validation.error_if_invalid = true
+ *     lenient:
+ *       - SET LOCAL myapp.geometry_validation.error_if_invalid = false
+ *   preCommit:
+ *     always:
+ *       - SELECT myapp.update_derived_data()
+ *     strict:
+ *       - SELECT myapp.assert_consistency()
+ * ```
  * </code>
  */
 @Value.Immutable
@@ -140,9 +160,62 @@ public interface TransactionsConfiguration extends ExtensionConfiguration {
    *     der API-Ebene zusammengeführt (Duplikate werden entfernt). Ist die effektive Liste für eine
    *     Sammlung leer, sind Teil-Aktualisierungen für diese Sammlung deaktiviert.
    * @default []
-   * @since v4.9
+   * @since v4.8
    */
   List<String> getUpdatableProperties();
+
+  /**
+   * @langEn SQL statements executed on the database transaction right after it begins, before any
+   *     action runs. Typical uses are transaction-scoped settings (`SET LOCAL …`) or calling a
+   *     setup function. Each entry is a single statement run verbatim, in order, on the provider's
+   *     transaction connection (PostgreSQL/PostGIS feature providers only). The `always`, `strict`
+   *     and `lenient` lists select which statements run depending on the request's `Prefer:
+   *     handling` preference. A statement that fails aborts the transaction.
+   * @langDe SQL-Anweisungen, die auf der Datenbanktransaktion direkt nach deren Beginn ausgeführt
+   *     werden, bevor eine Aktion läuft. Typische Anwendungen sind transaktionsbezogene
+   *     Einstellungen (`SET LOCAL …`) oder der Aufruf einer Setup-Funktion. Jeder Eintrag ist eine
+   *     einzelne Anweisung, die unverändert und in der angegebenen Reihenfolge auf der
+   *     Transaktionsverbindung des Providers ausgeführt wird (nur PostgreSQL/PostGIS-Provider). Die
+   *     Listen `always`, `strict` und `lenient` legen abhängig von der `Prefer: handling`-Präferenz
+   *     der Anfrage fest, welche Anweisungen laufen. Eine fehlschlagende Anweisung bricht die
+   *     Transaktion ab.
+   * @default null
+   * @since v4.8
+   */
+  @Nullable
+  TransactionHooks getTransactionSetup();
+
+  /**
+   * @langEn SQL statements executed on the database transaction right before it is committed.
+   *     Typical uses are calling functions that update derived data or verify consistency. Each
+   *     entry is a single statement run verbatim, in order, on the provider's transaction
+   *     connection (PostgreSQL/PostGIS feature providers only). The `always`, `strict` and
+   *     `lenient` lists select which statements run depending on the request's `Prefer: handling`
+   *     preference. A statement that raises an error aborts the transaction and rolls it back; a
+   *     statement that only emits a warning (`RAISE WARNING` / `RAISE NOTICE`) lets the transaction
+   *     commit and the warning is returned in the response. The error and warning text is relayed
+   *     verbatim into the response (`exceptions` and `warnings`), and the statements run at the
+   *     database level without access to the request actions, so write `RAISE` messages that
+   *     identify the affected feature(s) — e.g. include the feature identifier — to make the
+   *     response actionable.
+   * @langDe SQL-Anweisungen, die auf der Datenbanktransaktion direkt vor dem Commit ausgeführt
+   *     werden. Typische Anwendungen sind Funktionen, die abgeleitete Daten aktualisieren oder die
+   *     Konsistenz prüfen. Jeder Eintrag ist eine einzelne Anweisung, die unverändert und in der
+   *     angegebenen Reihenfolge auf der Transaktionsverbindung des Providers ausgeführt wird (nur
+   *     PostgreSQL/PostGIS-Provider). Die Listen `always`, `strict` und `lenient` legen abhängig
+   *     von der `Prefer: handling`-Präferenz der Anfrage fest, welche Anweisungen laufen. Eine
+   *     Anweisung, die einen Fehler auslöst, bricht die Transaktion ab und macht sie rückgängig;
+   *     eine Anweisung, die nur eine Warnung ausgibt (`RAISE WARNING` / `RAISE NOTICE`), lässt die
+   *     Transaktion committen, und die Warnung wird in der Antwort zurückgegeben. Der Fehler- bzw.
+   *     Warnungstext wird unverändert in die Antwort übernommen (`exceptions` und `warnings`), und
+   *     die Anweisungen laufen auf Datenbankebene ohne Zugriff auf die Aktionen der Anfrage. Daher
+   *     sollten `RAISE`-Meldungen die betroffenen Objekte benennen — z.B. den Objektidentifikator
+   *     enthalten —, damit die Antwort auswertbar ist.
+   * @default null
+   * @since v4.8
+   */
+  @Nullable
+  TransactionHooks getPreCommit();
 
   @Value.Derived
   @Value.Auxiliary

--- a/ogcapi-draft/ogcapi-transactions/src/test/groovy/de/ii/ogcapi/transactions/app/CommandHandlerTransactionsSpec.groovy
+++ b/ogcapi-draft/ogcapi-transactions/src/test/groovy/de/ii/ogcapi/transactions/app/CommandHandlerTransactionsSpec.groovy
@@ -190,9 +190,9 @@ class CommandHandlerTransactionsSpec extends Specification {
                 OgcApi api,
                 ApiRequestContext requestContext,
                 EpsgCrs requestCrs,
-                boolean validate,
+                HeaderPrefer.Handling handling,
                 Optional<Instant> ogcMutationDatetime) {
-            this.validate = validate
+            this.validate = handling == HeaderPrefer.Handling.STRICT
             Iterator<TxAction> it = transaction.actions()
             while (it.hasNext()) {
                 it.next()

--- a/ogcapi-draft/ogcapi-transactions/src/test/groovy/de/ii/ogcapi/transactions/domain/TransactionHooksSpec.groovy
+++ b/ogcapi-draft/ogcapi-transactions/src/test/groovy/de/ii/ogcapi/transactions/domain/TransactionHooksSpec.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.transactions.domain
+
+import de.ii.ogcapi.foundation.domain.HeaderPrefer
+import spock.lang.Specification
+
+class TransactionHooksSpec extends Specification {
+
+    def "effective() appends the strict list to always under STRICT handling"() {
+        given:
+        def hooks = new ImmutableTransactionHooks.Builder()
+                .addAlways("a1")
+                .addStrict("s1")
+                .addLenient("l1")
+                .build()
+
+        when:
+        def result = hooks.effective(HeaderPrefer.Handling.STRICT)
+
+        then:
+        result == ["a1", "s1"]
+    }
+
+    def "effective() appends the lenient list to always under LENIENT handling"() {
+        given:
+        def hooks = new ImmutableTransactionHooks.Builder()
+                .addAlways("a1")
+                .addStrict("s1")
+                .addLenient("l1")
+                .build()
+
+        when:
+        def result = hooks.effective(HeaderPrefer.Handling.LENIENT)
+
+        then:
+        result == ["a1", "l1"]
+    }
+
+    def "effective() preserves order and returns only always when no handling-specific entries"() {
+        given:
+        def hooks = new ImmutableTransactionHooks.Builder()
+                .addAlways("a1")
+                .addAlways("a2")
+                .build()
+
+        expect:
+        hooks.effective(HeaderPrefer.Handling.STRICT) == ["a1", "a2"]
+        hooks.effective(HeaderPrefer.Handling.LENIENT) == ["a1", "a2"]
+    }
+
+    def "effective() is empty for an empty hooks object"() {
+        given:
+        def hooks = new ImmutableTransactionHooks.Builder().build()
+
+        expect:
+        hooks.effective(HeaderPrefer.Handling.STRICT).isEmpty()
+        hooks.effective(HeaderPrefer.Handling.LENIENT).isEmpty()
+    }
+
+    def "mergeInto replaces the hook objects and concatenates updatableProperties"() {
+        given:
+        def apiLevel = new ImmutableTransactionsConfiguration.Builder()
+                .addUpdatableProperties("name")
+                .transactionSetup(new ImmutableTransactionHooks.Builder().addAlways("SET LOCAL a = 1").build())
+                .build()
+        def collectionLevel = new ImmutableTransactionsConfiguration.Builder()
+                .addUpdatableProperties("tags")
+                .preCommit(new ImmutableTransactionHooks.Builder().addStrict("SELECT check()").build())
+                .build()
+
+        when:
+        def merged = (TransactionsConfiguration) collectionLevel.mergeInto(apiLevel)
+
+        then:
+        merged.updatableProperties as Set == ["name", "tags"] as Set
+        merged.transactionSetup == apiLevel.transactionSetup
+        merged.preCommit == collectionLevel.preCommit
+    }
+}


### PR DESCRIPTION
### Pull request checklist

-   [x] Added/updated unit tests
-   [x] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

A follow-up to #1627 and #1634.

Depends on https://github.com/ldproxy/xtraplatform-spatial/pull/552.

Adds two API-level options to the TRANSACTIONS building block that run configurable SQL on the write transaction: `transactionSetup` (right after the transaction begins, e.g. `SET LOCAL ...`) and `preCommit` (right before commit, e.g. consistency checks or derived-data updates). Each option selects statements by the request's `Prefer: handling` preference through `always`/`strict`/`lenient` buckets. A pre-commit error rolls the transaction back and is reported; a warning lets it commit and is returned to the client.

- TransactionHooks: new value type with `always`/`strict`/`lenient` lists and effective(handling). TransactionsConfiguration gains `transactionSetup` and `preCommit`.
- TransactionExecutor.execute takes the `Prefer: handling` value (replacing the derived validate flag); executeAtomic and executeBatch run the setup and pre-commit statements and accumulate their warnings.
- ExecutionResult gains warnings; CommandHandlerTransactionsImpl renders a top-level warnings array, including on the no-content return path when warnings are present.
- Hook failures surface as FeatureMutationHookException carrying the warnings emitted before the failure; the executor recovers them and logs the configuration-driven rollback at debug without a stack trace.
