### PR TITLE
GML: fix objectTypeSuffixedProperties option

### DIFF
--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/FeaturesFormatGml.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/FeaturesFormatGml.java
@@ -535,6 +535,8 @@ public class FeaturesFormatGml extends FeatureFormatExtension implements Conform
         .xmlAttributes(remapList(config.getXmlAttributes(), aliasRewrites))
         .codelistProperties(remapKeys(config.getCodelistProperties(), aliasRewrites))
         .valueWrap(remapKeys(config.getValueWrap(), aliasRewrites))
+        .objectTypeSuffixedProperties(
+            remapList(config.getObjectTypeSuffixedProperties(), aliasRewrites))
         .codelists(resolveCodelists(config.getCodelistProperties()))
         .appendTemporalSuffixToGmlId(
             Boolean.TRUE.equals(config.getAppendTemporalSuffixToGmlId())
@@ -923,8 +925,9 @@ public class FeaturesFormatGml extends FeatureFormatExtension implements Conform
         .variableObjectElementNames(variableObjectElementNames)
         .xmlAttributes(config.getXmlAttributes())
         .valueWrap(config.getValueWrap())
-        // matched against the property name/alias on the wire; the decoder applies useAlias itself,
-        // so the configured names are passed through unchanged (as for codelistProperties above).
+        // The configured property ids are passed through unchanged: the decoder matches them
+        // against each property's technical full path (it never sees the alias rewrites, which are
+        // an encoder-only concern), so no remapping is applied here.
         .objectTypeSuffixedProperties(config.getObjectTypeSuffixedProperties())
         .build();
   }

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/GmlWriterProperties.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/GmlWriterProperties.java
@@ -72,7 +72,10 @@ public class GmlWriterProperties implements GmlWriter {
       // the _{objectType} suffix; it is resolved from the reference's type value (see onValue) or
       // removed at flush when the reference has no resolvable type.
       if (schema.isFeatureRef()
-          && context.encoding().getObjectTypeSuffixedProperties().contains(schema.getName())) {
+          && context
+              .encoding()
+              .getObjectTypeSuffixedProperties()
+              .contains(schema.getFullPathAsString())) {
         elementNameProperty += context.encoding().beginRefSuffix();
       }
       // Open the property element; its '>' is still pending (lazy emission)

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/CollectionEncodingGml.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/CollectionEncodingGml.java
@@ -27,9 +27,10 @@ import org.immutables.value.Value;
  * pre-computed here at encoder-build time:
  *
  * <ul>
- *   <li>{@link #getXmlAttributes()}, {@link #getCodelistProperties()}, {@link #getValueWrap()} —
- *       their path keys are alias-rewritten (technical → alias) when {@code useAlias} is on, to
- *       match the alias-form paths {@code GmlWriterProperties} sees at runtime;
+ *   <li>{@link #getXmlAttributes()}, {@link #getCodelistProperties()}, {@link #getValueWrap()},
+ *       {@link #getObjectTypeSuffixedProperties()} — their path keys are alias-rewritten (id →
+ *       alias) when {@code useAlias} is on, to match the alias-form paths {@code
+ *       GmlWriterProperties} sees at runtime;
  *   <li>{@link #getCodelists()} — the codelist ids are resolved to {@code Codelist} instances via
  *       the codelist store;
  *   <li>{@link #getAppendTemporalSuffixToGmlId()} — the configured flag folded with whether the
@@ -58,6 +59,11 @@ public interface CollectionEncodingGml {
   @Value.Default
   default Map<String, List<String>> getValueWrap() {
     return ImmutableMap.of();
+  }
+
+  @Value.Default
+  default List<String> getObjectTypeSuffixedProperties() {
+    return ImmutableList.of();
   }
 
   @Value.Default

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/FeatureTransformationContextGml.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/FeatureTransformationContextGml.java
@@ -181,7 +181,9 @@ public abstract class FeatureTransformationContextGml implements FeatureTransfor
   }
 
   public List<String> getObjectTypeSuffixedProperties() {
-    return currentEncoding().getConfig().getObjectTypeSuffixedProperties();
+    // Alias-rewritten in the bundle (technical id → alias path) when useAlias is on, so this
+    // matches the alias-form paths GmlWriterProperties sees at runtime (as for getXmlAttributes).
+    return currentEncoding().getObjectTypeSuffixedProperties();
   }
 
   public boolean getGmlIdOnGeometries() {

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/GmlConfiguration.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/GmlConfiguration.java
@@ -555,20 +555,18 @@ public interface GmlConfiguration
   /**
    * @langEn Some feature reference properties are encoded in GML with a property element name that
    *     appends the referenced feature type to the property name, for example
-   *     `adv:gehoertZuBauwerk_AX_Turm` instead of `adv:gehoertZuBauwerk`. List the affected
-   *     properties here. On encoding, the property element name receives a `_{objectType}` suffix
-   *     where `{objectType}` is the object type of the collection that the reference points to; on
-   *     decoding, an element name with such a suffix is mapped back to the property. Use the
-   *     property name as it appears in the GML element, that is, the alias when `useAlias` is
-   *     enabled.
+   *     `gehoertZuBauwerk_AX_Turm` instead of `gehoertZuBauwerk`. List the affected properties
+   *     here, identified by their property id. On encoding, the property element name receives a
+   *     `_{objectType}` suffix where `{objectType}` is the object type of the collection that the
+   *     reference points to; on decoding, an element name with such a suffix is mapped back to the
+   *     property.
    * @langDe Einige Eigenschaften mit Objektreferenzen werden in GML mit einem Elementnamen kodiert,
    *     der den referenzierten Objekttyp an den Eigenschaftsnamen anhängt, zum Beispiel
-   *     `adv:gehoertZuBauwerk_AX_Turm` statt `adv:gehoertZuBauwerk`. Hier werden die betroffenen
-   *     Eigenschaften aufgelistet. Bei der Kodierung erhält der Elementname ein
-   *     `_{objectType}`-Suffix, wobei `{objectType}` der Objekttyp der Collection ist, auf die die
-   *     Referenz verweist; bei der Dekodierung wird ein Elementname mit einem solchen Suffix wieder
-   *     auf die Eigenschaft abgebildet. Es ist der Eigenschaftsname zu verwenden, wie er im
-   *     GML-Element erscheint, also der Alias, wenn `useAlias` aktiviert ist.
+   *     `gehoertZuBauwerk_AX_Turm` statt `gehoertZuBauwerk`. Hier werden die betroffenen
+   *     Eigenschaften aufgelistet, angegeben über ihre Property-Id. Bei der Kodierung erhält der
+   *     Elementname ein `_{objectType}`-Suffix, wobei `{objectType}` der Objekttyp der Collection
+   *     ist, auf die die Referenz verweist; bei der Dekodierung wird ein Elementname mit einem
+   *     solchen Suffix wieder auf die Eigenschaft abgebildet.
    * @default []
    * @examplesAll <code>
    * ```yaml
@@ -1100,6 +1098,8 @@ public interface GmlConfiguration
         .codelistProperties(mergeMaps(src.getCodelistProperties(), getCodelistProperties()))
         .valueWrap(mergeMaps(src.getValueWrap(), getValueWrap()))
         .xmlAttributes(mergeLists(src.getXmlAttributes(), getXmlAttributes()))
+        .objectTypeSuffixedProperties(
+            mergeLists(src.getObjectTypeSuffixedProperties(), getObjectTypeSuffixedProperties()))
         .srsNameMappings(mergeLists(src.getSrsNameMappings(), getSrsNameMappings()))
         .uomMappings(mergeLists(src.getUomMappings(), getUomMappings()))
         .transformations(


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [x] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

All GML configuration options related to properties use the property id. objectTypeSuffixedProperties was an exception in that it used the XML element name (which might also be the alias). This change fixes this and aligns the configuration option with the other GML configuration options.