### PR TITLE
Search: single-shot and paging support; fix links

### DIFF
--- a/gradle/layers.versions.toml
+++ b/gradle/layers.versions.toml
@@ -1,5 +1,5 @@
 [versions]
 xtraplatform-core    = '7.0.0-SNAPSHOT'
 xtraplatform-native  = '2.6.0-SNAPSHOT'
-xtraplatform-spatial = '8.0.0-SNAPSHOT'
+xtraplatform-spatial = '8.0.0-multi-feature-query-scopes-SNAPSHOT'
 

--- a/gradle/layers.versions.toml
+++ b/gradle/layers.versions.toml
@@ -1,5 +1,5 @@
 [versions]
 xtraplatform-core    = '7.0.0-SNAPSHOT'
 xtraplatform-native  = '2.6.0-SNAPSHOT'
-xtraplatform-spatial = '8.0.0-multi-feature-query-scopes-SNAPSHOT'
+xtraplatform-spatial = '8.0.0-SNAPSHOT'
 

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/EndpointAdHocQuery.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/EndpointAdHocQuery.java
@@ -17,6 +17,7 @@ import de.ii.ogcapi.features.core.domain.EndpointRequiresFeatures;
 import de.ii.ogcapi.features.core.domain.FeatureFormatExtension;
 import de.ii.ogcapi.features.core.domain.FeaturesCoreConfiguration;
 import de.ii.ogcapi.features.core.domain.FeaturesCoreProviders;
+import de.ii.ogcapi.features.search.domain.ImmutableQueryExpression;
 import de.ii.ogcapi.features.search.domain.ImmutableQueryInputQuery;
 import de.ii.ogcapi.features.search.domain.QueryExpression;
 import de.ii.ogcapi.features.search.domain.SearchConfiguration;
@@ -267,6 +268,15 @@ public class EndpointAdHocQuery extends EndpointRequiresFeatures
       throw new IllegalArgumentException(
           String.format("The content of the query expression is invalid: %s", e.getMessage()), e);
     }
+
+    // ad-hoc queries are submitted via POST and have no addressable GET resource, so they cannot
+    // offer paging links; paging is not supported and the result is always single-shot
+    if (query.getSupportPaging().orElse(false)) {
+      throw new IllegalArgumentException(
+          "Paging is not supported for ad-hoc queries; there is no addressable resource to page "
+              + "through. Use a stored query for paging, or set \"supportPaging\" to false.");
+    }
+    query = new ImmutableQueryExpression.Builder().from(query).supportPaging(false).build();
 
     FeaturesCoreConfiguration coreConfiguration =
         apiData.getExtension(FeaturesCoreConfiguration.class).orElseThrow();

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/QueryParameterOffsetStoredQuery.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/QueryParameterOffsetStoredQuery.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.features.search.app;
+
+import com.github.azahnen.dagger.annotations.AutoBind;
+import de.ii.ogcapi.features.search.domain.ImmutableStoredQueryExpression;
+import de.ii.ogcapi.features.search.domain.QueryExpressionQueryParameter;
+import de.ii.ogcapi.features.search.domain.SearchConfiguration;
+import de.ii.ogcapi.foundation.domain.ExtensionConfiguration;
+import de.ii.ogcapi.foundation.domain.ExternalDocumentation;
+import de.ii.ogcapi.foundation.domain.FeatureTypeConfigurationOgcApi;
+import de.ii.ogcapi.foundation.domain.OgcApi;
+import de.ii.ogcapi.foundation.domain.OgcApiDataV2;
+import de.ii.ogcapi.foundation.domain.OgcApiQueryParameterBase;
+import de.ii.ogcapi.foundation.domain.QueryParameterSet;
+import de.ii.ogcapi.foundation.domain.SchemaValidator;
+import de.ii.ogcapi.foundation.domain.SpecificationMaturity;
+import de.ii.ogcapi.foundation.domain.TypedQueryParameter;
+import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * @title offset
+ * @endpoints Stored Query
+ * @langEn The index of the first feature in the response in the overall result set. This parameter
+ *     is used for response paging.
+ * @langDe Der Index des ersten Features in der Antwort in der Gesamtergebnismenge. Dieser Parameter
+ *     wird für das Paging verwendet.
+ */
+@Singleton
+@AutoBind
+public class QueryParameterOffsetStoredQuery extends OgcApiQueryParameterBase
+    implements TypedQueryParameter<Integer>, QueryExpressionQueryParameter {
+
+  private Schema<?> schema;
+
+  private final SchemaValidator schemaValidator;
+
+  @Inject
+  QueryParameterOffsetStoredQuery(SchemaValidator schemaValidator) {
+    super();
+    this.schemaValidator = schemaValidator;
+  }
+
+  @Override
+  public String getId() {
+    return "offsetStoredQuery";
+  }
+
+  @Override
+  public String getName() {
+    return "offset";
+  }
+
+  @Override
+  public Integer parse(
+      String value,
+      Map<String, Object> typedValues,
+      OgcApi api,
+      Optional<FeatureTypeConfigurationOgcApi> optionalCollectionData) {
+    try {
+      return Objects.nonNull(value) ? Integer.parseInt(value) : 0;
+    } catch (Throwable e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Invalid value for query parameter '%s'. The value must be a non-negative integer. Found: %s.",
+              getName(), value),
+          e);
+    }
+  }
+
+  @Override
+  public String getDescription() {
+    return "The optional offset parameter identifies the index of the first feature in the response in the overall "
+        + "result set.";
+  }
+
+  @Override
+  public boolean matchesPath(String definitionPath) {
+    return "/search/{queryId}".equals(definitionPath);
+  }
+
+  @Override
+  public Schema<?> getSchema(OgcApiDataV2 apiData) {
+    if (schema == null) {
+      schema = new IntegerSchema()._default(0).minimum(BigDecimal.ZERO);
+    }
+    return schema;
+  }
+
+  @Override
+  public SchemaValidator getSchemaValidator() {
+    return schemaValidator;
+  }
+
+  @Override
+  public Class<? extends ExtensionConfiguration> getBuildingBlockConfigurationType() {
+    return SearchConfiguration.class;
+  }
+
+  @Override
+  public Optional<SpecificationMaturity> getSpecificationMaturity() {
+    return SearchBuildingBlock.MATURITY;
+  }
+
+  @Override
+  public Optional<ExternalDocumentation> getSpecificationRef() {
+    return SearchBuildingBlock.SPEC;
+  }
+
+  @Override
+  public void applyTo(
+      ImmutableStoredQueryExpression.Builder builder, QueryParameterSet queryParameterSet) {
+    builder.offset(queryParameterSet.getValue(this));
+  }
+}

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/SearchBuildingBlock.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/SearchBuildingBlock.java
@@ -86,12 +86,13 @@ import java.util.Optional;
  *     <p><code>
  * - A "title" and "description" for the query expression can be added. Providing both is
  *     strongly recommended to explain the query to users.
- * - The "limit" member applies to the entire result set. Responses are single-shot: there is no
- *     paging and no "next" links, "limit" is an upper bound for the number of features in the
- *     response.
- * - By default the response includes "numberMatched". Setting "computeNumberMatched" to false
- *     skips it; this avoids a count query per query and can be considerably faster for query
- *     expressions with many or chained queries. "numberMatched" is then not reported.
+ * - By default the result set is returned single-shot: all matching features in one pass, with no
+ *     paging links and without "numberMatched"/"numberReturned"; this avoids a count query per
+ *     (sub-)query and is considerably faster for large result sets. A stored query may set
+ *     "supportPaging" to true to be paged instead: the response then reports "numberMatched" and
+ *     "numberReturned" and the result can be retrieved page by page via "offset", with "next"/"prev"
+ *     links. Ad-hoc queries (POST) are always single-shot, as there is no addressable URL to page
+ *     through.
  * - The “crs” and “verticalCrs” members are optional and can be used to specify the coordinate
  *     reference system for the coordinates in the response. If no value is specified, the default
  *     coordinate reference system is used. If "verticalCrs" is specified, then it must be the URI
@@ -156,8 +157,7 @@ import java.util.Optional;
  *     <p>Allgemeines:
  *     <p><code>
  * - Ein "Titel" und eine "Beschreibung" für die Query Expression können hinzugefügt werden. Es wird dringend empfohlen, beides anzugeben, um Benutzern die Abfrage zu erklären.
- * - Das Element "limit" gilt für die gesamte Ergebnismenge. Antworten werden nicht in Seiten aufgeteilt: Es gibt kein Paging und keine "next"-Links, "limit" ist eine Obergrenze für die Anzahl der Features in der Antwort.
- * - Standardmäßig enthält die Antwort "numberMatched". Wird "computeNumberMatched" auf false gesetzt, wird darauf verzichtet; dies vermeidet eine Count-Abfrage pro Abfrage und kann bei Query Expressions mit vielen oder verketteten Abfragen deutlich schneller sein. "numberMatched" wird dann nicht ausgegeben.
+ * - Standardmäßig wird die Ergebnismenge in einem Durchgang ausgegeben: alle passenden Features auf einmal, ohne Paging-Links und ohne "numberMatched"/"numberReturned"; dies vermeidet eine Count-Abfrage pro (Unter-)Abfrage und ist bei großen Ergebnismengen deutlich schneller. Eine Stored Query kann "supportPaging" auf true setzen, um stattdessen seitenweise ausgegeben zu werden: Die Antwort enthält dann "numberMatched" und "numberReturned" und die Ergebnismenge kann über "offset" seitenweise abgerufen werden, mit "next"/"prev"-Links. Ad-hoc-Abfragen (POST) werden immer in einem Durchgang ausgegeben, da es keine adressierbare URL für das Paging gibt.
  * - Die Elemente "crs" und "verticalCrs" sind optional und können verwendet werden, um das Koordinatenreferenzsystem für die Koordinaten in der Antwort zu spezifizieren. Ist kein Wert angegeben, dann wird das Standard-Koordinatenreferenzsystem verwendet. Ist "verticalCrs" angegeben, dann muss es die URI eines vertikalen Koordinatenreferenzsystem sind und "crs" angegeben sein und die URI eines horizontales 2D-Koordinatenreferenzsystem sein.
  * - "sortby" wird nur pro Abfrage angewendet. Ein globales "sortby" würde erfordern, dass die Ergebnisse aller Abfragen zuerst kompiliert werden und dann die kombinierte Ergebnismenge sortiert wird. Dies würde das "Streaming" der Antwort nicht unterstützen.
  * - Im Falle einer parametrisierten gespeicherten Abfrage kann der Abfrageausdruck JSON-Objekte mit einem Member "$parameter" enthalten. Der Wert von "$parameter" ist ein Objekt mit einem Key-Value-Paar, bei dem der Schlüssel der Parametername und der Wert ein JSON-Schema ist, das den Parameter beschreibt. Bei der Ausführung der gespeicherten Abfrage werden alle Objekte mit einem "$parameter"-Member durch den Wert des Parameters für diese Abfrageausführung ersetzt. Kommagetrennte Parameterwerte werden in ein Array umgewandelt, wenn der Parameter vom Typ "array" ist.

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/SearchQueriesHandlerImpl.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/SearchQueriesHandlerImpl.java
@@ -13,6 +13,7 @@ import com.google.common.collect.ImmutableMap;
 import de.ii.ogcapi.collections.queryables.domain.QueryablesConfiguration;
 import de.ii.ogcapi.features.core.domain.DelayedOutputStream;
 import de.ii.ogcapi.features.core.domain.FeatureFormatExtension;
+import de.ii.ogcapi.features.core.domain.FeatureQueryScope;
 import de.ii.ogcapi.features.core.domain.FeaturesCoreConfiguration;
 import de.ii.ogcapi.features.core.domain.FeaturesCoreProviders;
 import de.ii.ogcapi.features.core.domain.ImmutableFeatureTransformationContextGeneric;
@@ -691,7 +692,10 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
             outputFormat,
             queryInput.getDefaultCrs(),
             targetCrs,
-            queryInput.includeBodyLinks() ? links : List.of());
+            queryInput.includeBodyLinks() ? links : List.of(),
+            queryInput.isStoredQuery()
+                ? FeatureQueryScope.STORED_QUERY
+                : FeatureQueryScope.AD_HOC_QUERY);
 
     StreamingOutput streamingOutput = streamingOutputAndMetadata.first();
     CollectionMetadata collectionMetadata = streamingOutputAndMetadata.second();
@@ -993,7 +997,8 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
       FeatureFormatExtension outputFormat,
       EpsgCrs defaultCrs,
       EpsgCrs targetCrs,
-      List<Link> links) {
+      List<Link> links,
+      FeatureQueryScope queryScope) {
     OgcApi api = requestContext.getApi();
     EpsgCrs sourceCrs = null;
     Optional<CrsTransformer> crsTransformer = Optional.empty();
@@ -1103,6 +1108,7 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
             .idsIncludeCollectionId(
                 collectionIds.size() > 1 && !featureProvider.info().featureIdsAreGloballyUnique())
             .queryId(queryExpression.getId())
+            .queryScope(queryScope)
             .queryTitle(queryExpression.getTitle())
             .queryDescription(queryExpression.getDescription());
 

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/SearchQueriesHandlerImpl.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/SearchQueriesHandlerImpl.java
@@ -664,6 +664,9 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
             ? new StoredQueriesLinkGenerator()
                 .generateFeaturesLinks(
                     requestContext.getUriCustomizer(),
+                    query.getOffset(),
+                    query.getLimit(),
+                    query.getSupportPaging(),
                     requestContext.getMediaType(),
                     requestContext.getAlternateMediaTypes(),
                     i18n,
@@ -694,7 +697,9 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
             targetCrs,
             queryInput.includeBodyLinks() ? links : List.of(),
             queryInput.isStoredQuery()
-                ? FeatureQueryScope.STORED_QUERY
+                ? (query.getSupportPaging()
+                    ? FeatureQueryScope.STORED_QUERY
+                    : FeatureQueryScope.STORED_QUERY_SINGLE_SHOT)
                 : FeatureQueryScope.AD_HOC_QUERY);
 
     StreamingOutput streamingOutput = streamingOutputAndMetadata.first();
@@ -745,7 +750,9 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
         ImmutableMultiFeatureQuery.builder()
             .queries(queries)
             .deduplicate(queryExpression.getDeduplicate())
-            .computeNumberMatched(queryExpression.getComputeNumberMatched())
+            // single-shot by default; a stored query opts into paging with supportPaging:true
+            .supportPaging(queryExpression.getSupportPaging().orElse(false))
+            .offset(queryExpression.getOffset().orElse(0))
             .maxAllowableOffset(queryExpression.getMaxAllowableOffset().orElse(0.0))
             .crs(crs)
             .limit(
@@ -756,6 +763,12 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
                             .getExtension(FeaturesCoreConfiguration.class)
                             .map(FeaturesCoreConfiguration::getDefaultPageSize)
                             .orElseThrow()));
+
+    // server-side cap applied per query in single-shot mode (no effect when paging is enabled)
+    api.getData()
+        .getExtension(SearchConfiguration.class)
+        .map(SearchConfiguration::getMaximumFeaturesPerQuery)
+        .ifPresent(finalQueryBuilder::maxFeaturesPerSubQuery);
 
     api.getData()
         .getExtension(FeaturesCoreConfiguration.class)

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/StoredQueriesLinkGenerator.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/StoredQueriesLinkGenerator.java
@@ -24,6 +24,13 @@ public class StoredQueriesLinkGenerator extends DefaultLinksGenerator {
 
   public static final String NAME_TEMPLATE = "{{name}}";
   public static final String PARAMETER_TEMPLATE = "{{parameter}}";
+  public static final String OFFSET = "offset";
+  public static final String NEXT = "next";
+  public static final String NEXT_LINK = "nextLink";
+  public static final String PREV = "prev";
+  public static final String PREV_LINK = "prevLink";
+  public static final String FIRST = "first";
+  public static final String FIRST_LINK = "firstLink";
   public static final String PARAMETERS = "parameters";
   public static final String DESCRIBEDBY = "describedby";
   public static final String QUERY_PARAMETERS_LINK = "queryParametersLink";
@@ -211,13 +218,65 @@ public class StoredQueriesLinkGenerator extends DefaultLinksGenerator {
     builder.add(selfBuilder.build());
   }
 
-  // responses of query expressions are single-shot, there are no paging links
   public List<Link> generateFeaturesLinks(
       URICustomizer uriBuilder,
+      int offset,
+      int limit,
+      boolean supportPaging,
       ApiMediaType mediaType,
       List<ApiMediaType> alternateMediaTypes,
       I18n i18n,
       Optional<Locale> language) {
-    return super.generateLinks(uriBuilder, mediaType, alternateMediaTypes, i18n, language);
+    List<Link> standardLinks =
+        super.generateLinks(uriBuilder, mediaType, alternateMediaTypes, i18n, language);
+    if (!supportPaging) {
+      // single-shot responses are not paged, so there are no paging links
+      return standardLinks;
+    }
+
+    final ImmutableList.Builder<Link> builder =
+        new ImmutableList.Builder<Link>().addAll(standardLinks);
+
+    uriBuilder.removeParameters(LANG);
+
+    // the "next" link is added speculatively (numberMatched is not yet known) and removed again by
+    // the feature encoder when this is the last page (numberReturned < limit)
+    builder.add(
+        new ImmutableLink.Builder()
+            .href(getUrlWithOffset(uriBuilder.copy(), offset + limit))
+            .rel(NEXT)
+            .type(mediaType.type().toString())
+            .title(i18n.get(NEXT_LINK, language))
+            .build());
+    if (offset > 0) {
+      builder.add(
+          new ImmutableLink.Builder()
+              .href(getUrlWithOffset(uriBuilder.copy(), offset - limit))
+              .rel(PREV)
+              .type(mediaType.type().toString())
+              .title(i18n.get(PREV_LINK, language))
+              .build());
+      builder.add(
+          new ImmutableLink.Builder()
+              .href(getUrlWithOffset(uriBuilder.copy(), 0))
+              .rel(FIRST)
+              .type(mediaType.type().toString())
+              .title(i18n.get(FIRST_LINK, language))
+              .build());
+    }
+
+    return builder.build();
+  }
+
+  private String getUrlWithOffset(final URICustomizer uriBuilder, final int offset) {
+    if (offset == 0) {
+      return uriBuilder.ensureNoTrailingSlash().removeParameters(OFFSET).toString();
+    }
+
+    return uriBuilder
+        .ensureNoTrailingSlash()
+        .removeParameters(OFFSET)
+        .setParameter(OFFSET, String.valueOf(Integer.max(0, offset)))
+        .toString();
   }
 }

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/ParameterResolver.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/ParameterResolver.java
@@ -51,7 +51,8 @@ public class ParameterResolver implements ParameterResolverBase {
             .title(storedQuery.getTitle())
             .description(storedQuery.getDescription());
     storedQuery.getDeduplicate().ifPresent(builder::deduplicate);
-    storedQuery.getComputeNumberMatched().ifPresent(builder::computeNumberMatched);
+    storedQuery.getSupportPaging().ifPresent(builder::supportPaging);
+    storedQuery.getOffset().ifPresent(builder::offset);
 
     storedQuery
         .getCollections()

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/QueryExpression.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/QueryExpression.java
@@ -74,18 +74,21 @@ public interface QueryExpression {
 
   Optional<Integer> getLimit();
 
+  // index of the first feature in the overall result set (paging); only used when paging is enabled
+  Optional<Integer> getOffset();
+
   // if enabled, a feature that is selected by more than one query is only included once
   @Value.Default
   default boolean getDeduplicate() {
     return false;
   }
 
-  // if disabled, numberMatched is not computed (avoids a count query per query, which can be
-  // expensive for query expressions with many or chained queries)
-  @Value.Default
-  default boolean getComputeNumberMatched() {
-    return true;
-  }
+  // the response is single-shot by default (one pass over the whole result set, no meta queries, no
+  // numberMatched/numberReturned). A stored query may set this to true to be paged instead:
+  // numberMatched/numberReturned are reported and the result can be retrieved page by page via
+  // offset. Ad-hoc queries (POST) are always single-shot (an explicit true is rejected), as there
+  // is no addressable URL to page through.
+  Optional<Boolean> getSupportPaging();
 
   List<String> getProfiles();
 

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/SearchConfiguration.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/SearchConfiguration.java
@@ -135,6 +135,19 @@ public interface SearchConfiguration extends ExtensionConfiguration, CachingConf
     return Objects.equals(getAllLinksAreLocal(), true);
   }
 
+  /**
+   * @langEn Maximum number of features returned per query in a query expression when paging is
+   *     disabled (single-shot responses, `supportPaging` is `false`). Each query of the expression
+   *     is capped independently. Without a value, no limit is applied.
+   * @langDe Maximale Anzahl von Features, die pro Abfrage in einer Query Expression zurückgegeben
+   *     werden, wenn das Paging deaktiviert ist (`supportPaging` ist `false`). Jede Abfrage des
+   *     Ausdrucks wird unabhängig begrenzt. Ohne Angabe wird kein Limit angewendet.
+   * @default -
+   * @since v4.8
+   */
+  @Nullable
+  Integer getMaximumFeaturesPerQuery();
+
   abstract class Builder extends ExtensionConfiguration.Builder {}
 
   @Override

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/StoredQueryBase.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/domain/StoredQueryBase.java
@@ -59,11 +59,14 @@ public interface StoredQueryBase extends StoredQueryComponent {
   // Integer or Parameter
   Optional<IntegerOrParameter> getLimit();
 
+  // index of the first feature in the overall result set (paging); only used when paging is enabled
+  Optional<Integer> getOffset();
+
   // if enabled, a feature that is selected by more than one query is only included once
   Optional<Boolean> getDeduplicate();
 
-  // if disabled, numberMatched is not computed (avoids a count query per query)
-  Optional<Boolean> getComputeNumberMatched();
+  // single-shot by default; set true to page the result set
+  Optional<Boolean> getSupportPaging();
 
   // List of string or parameter, or a parameter that is a string array
   Optional<ParameterOrListOfStringOrParameter> getProfiles();

--- a/ogcapi-draft/ogcapi-features-search/src/test/groovy/de/ii/ogcapi/features/search/app/ResultSetSpec.groovy
+++ b/ogcapi-draft/ogcapi-features-search/src/test/groovy/de/ii/ogcapi/features/search/app/ResultSetSpec.groovy
@@ -46,14 +46,14 @@ class ResultSetSpec extends Specification {
         query.getQueries().get(1).getFilter().get() == InResultSet.of("dientZurDarstellungVon", "flst")
     }
 
-    def 'computeNumberMatched defaults to true and can be disabled'() {
+    def 'supportPaging is unset by default and parsed when present'() {
         given:
         String byDefault = """{ "queries": [ { "collections": [ "ax_flurstueck" ] } ] }"""
-        String disabled = """{ "computeNumberMatched": false, "queries": [ { "collections": [ "ax_flurstueck" ] } ] }"""
+        String paged = """{ "supportPaging": true, "queries": [ { "collections": [ "ax_flurstueck" ] } ] }"""
 
-        expect:
-        QueryExpression.of(new ByteArrayInputStream(byDefault.getBytes("UTF-8"))).getComputeNumberMatched()
-        !QueryExpression.of(new ByteArrayInputStream(disabled.getBytes("UTF-8"))).getComputeNumberMatched()
+        expect: 'unset is empty (the handler applies the single-shot default); an explicit value is parsed'
+        QueryExpression.of(new ByteArrayInputStream(byDefault.getBytes("UTF-8"))).getSupportPaging().isEmpty()
+        QueryExpression.of(new ByteArrayInputStream(paged.getBytes("UTF-8"))).getSupportPaging().get()
     }
 
     def 'the resultSet shorthand is equivalent to an id result set'() {

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeatureQueryScope.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeatureQueryScope.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.features.core.domain;
+
+/**
+ * Identifies what produced a features response, which governs link generation: an addressable
+ * collection resource, a transient ad-hoc query, or an addressable stored query.
+ */
+public enum FeatureQueryScope {
+  /** The items of a single collection (GET .../items): addressable and pageable. */
+  COLLECTION,
+  /**
+   * An ad-hoc query expression submitted via POST (.../search): there is no resource on the server
+   * to link to and the response is single-shot.
+   */
+  AD_HOC_QUERY,
+  /** A stored query executed via GET (.../search/{queryId}): addressable, but single-shot. */
+  STORED_QUERY;
+
+  /** Query expressions (ad-hoc and stored queries) are single-shot and not paged. */
+  public boolean isQueryExpression() {
+    return this != COLLECTION;
+  }
+
+  /** Whether there is an addressable resource that a canonical/self link may point to. */
+  public boolean hasCanonicalResource() {
+    return this != AD_HOC_QUERY;
+  }
+}

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeatureQueryScope.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeatureQueryScope.java
@@ -8,21 +8,29 @@
 package de.ii.ogcapi.features.core.domain;
 
 /**
- * Identifies what produced a features response, which governs link generation: an addressable
- * collection resource, a transient ad-hoc query, or an addressable stored query.
+ * Identifies what produced a features response, which governs link generation and paging: an
+ * addressable collection resource, a transient ad-hoc query, or an addressable stored query (paged
+ * or single-shot).
  */
 public enum FeatureQueryScope {
-  /** The items of a single collection (GET .../items): addressable and pageable. */
+  /** The items of a single collection (GET .../items): addressable, paged. */
   COLLECTION,
   /**
    * An ad-hoc query expression submitted via POST (.../search): there is no resource on the server
    * to link to and the response is single-shot.
    */
   AD_HOC_QUERY,
-  /** A stored query executed via GET (.../search/{queryId}): addressable, but single-shot. */
-  STORED_QUERY;
+  /**
+   * A stored query executed via GET (.../search/{queryId}) with paging support: addressable, paged.
+   */
+  STORED_QUERY,
+  /**
+   * A stored query executed via GET (.../search/{queryId}) without paging: addressable,
+   * single-shot.
+   */
+  STORED_QUERY_SINGLE_SHOT;
 
-  /** Query expressions (ad-hoc and stored queries) are single-shot and not paged. */
+  /** Query expressions (ad-hoc and stored queries) are submitted as a query expression. */
   public boolean isQueryExpression() {
     return this != COLLECTION;
   }
@@ -30,5 +38,10 @@ public enum FeatureQueryScope {
   /** Whether there is an addressable resource that a canonical/self link may point to. */
   public boolean hasCanonicalResource() {
     return this != AD_HOC_QUERY;
+  }
+
+  /** Whether the response is paged (and may advertise pagination controls and prev/next links). */
+  public boolean supportsPaging() {
+    return this == COLLECTION || this == STORED_QUERY;
   }
 }

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeatureTransformationContext.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeatureTransformationContext.java
@@ -166,9 +166,14 @@ public interface FeatureTransformationContext extends EncodingContextSfFlat {
 
   Optional<String> getQueryId();
 
+  @Value.Default
+  default FeatureQueryScope getQueryScope() {
+    return FeatureQueryScope.COLLECTION;
+  }
+
   @Value.Derived
   default boolean isQueryExpression() {
-    return getQueryId().isPresent();
+    return getQueryScope().isQueryExpression();
   }
 
   Optional<String> getQueryTitle();

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeatureTransformationContext.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/FeatureTransformationContext.java
@@ -176,6 +176,15 @@ public interface FeatureTransformationContext extends EncodingContextSfFlat {
     return getQueryScope().isQueryExpression();
   }
 
+  /**
+   * Whether the response is paged. When {@code false}, the response is single-shot and must not
+   * advertise pagination controls or prev/next links.
+   */
+  @Value.Derived
+  default boolean supportsPaging() {
+    return getQueryScope().supportsPaging();
+  }
+
   Optional<String> getQueryTitle();
 
   Optional<String> getQueryDescription();

--- a/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/app/FeaturesFormatHtml.java
+++ b/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/app/FeaturesFormatHtml.java
@@ -13,6 +13,7 @@ import com.github.azahnen.dagger.annotations.AutoBind;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import de.ii.ogcapi.features.core.domain.FeatureFormatExtension;
+import de.ii.ogcapi.features.core.domain.FeatureQueryScope;
 import de.ii.ogcapi.features.core.domain.FeatureTransformationContext;
 import de.ii.ogcapi.features.core.domain.FeaturesCoreConfiguration;
 import de.ii.ogcapi.features.core.domain.FeaturesCoreProviders;
@@ -297,6 +298,7 @@ public class FeaturesFormatHtml extends FeatureFormatExtension
               transformationContext.getQueryTitle().orElse("Search"),
               getPropertyTooltips(apiData, true),
               transformationContext.getLinks(),
+              transformationContext.getQueryScope(),
               user);
     } else {
       // Features - Core
@@ -638,6 +640,7 @@ public class FeaturesFormatHtml extends FeatureFormatExtension
       String queryLabel,
       boolean propertyTooltips,
       List<Link> links,
+      FeatureQueryScope queryScope,
       Optional<User> user) {
     OgcApiDataV2 apiData = api.getData();
     URI requestUri = null;
@@ -672,7 +675,7 @@ public class FeaturesFormatHtml extends FeatureFormatExtension
     URICustomizer resourceUri = uriCustomizer.copy().clearParameters();
 
     return ModifiableFeatureCollectionView.create()
-        .setFromStoredQuery(true)
+        .setQueryScope(queryScope)
         .setFilterEditor(null)
         .setApiData(apiData)
         .setSpatialExtent(api.getSpatialExtent())

--- a/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/domain/FeatureCollectionView.java
+++ b/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/domain/FeatureCollectionView.java
@@ -7,6 +7,7 @@
  */
 package de.ii.ogcapi.features.html.domain;
 
+import de.ii.ogcapi.features.core.domain.FeatureQueryScope;
 import java.util.List;
 import java.util.Map;
 import org.immutables.value.Value;
@@ -30,8 +31,8 @@ public abstract class FeatureCollectionView extends FeaturesView {
   }
 
   @Value.Default
-  public boolean fromStoredQuery() {
-    return false;
+  public FeatureQueryScope queryScope() {
+    return FeatureQueryScope.COLLECTION;
   }
 
   public abstract List<Map.Entry<String, String>> jsTranslations();

--- a/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/domain/FeatureEncoderHtml.java
+++ b/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/domain/FeatureEncoderHtml.java
@@ -57,6 +57,13 @@ public class FeatureEncoderHtml extends FeatureObjectEncoder<PropertyHtml, Featu
 
   @Override
   public void onStart(ModifiableContext context) {
+    // Query-expression responses (ad-hoc and stored queries) are single-shot: the 'limit'
+    // applies to the entire result set and offset-based paging is not supported (the endpoints
+    // reject 'limit'/'offset'), so no pagination or prev/next links are generated.
+    if (transformationContext.isQueryExpression()) {
+      return;
+    }
+
     if (transformationContext.isFeatureCollection()
         && context.metadata().getNumberReturned().isPresent()) {
       long returned = context.metadata().getNumberReturned().getAsLong();
@@ -77,40 +84,27 @@ public class FeatureEncoderHtml extends FeatureObjectEncoder<PropertyHtml, Featu
       LOGGER.debug("page {}", transformationContext.getPage());
       LOGGER.debug("pages {}", pages);
 
-      boolean includeLimit = !transformationContext.isQueryExpression();
-
       ImmutableList.Builder<NavigationDTO> pagination = new ImmutableList.Builder<>();
       ImmutableList.Builder<NavigationDTO> metaPagination = new ImmutableList.Builder<>();
       if (transformationContext.getPage() > 1) {
         pagination
             .add(
                 new NavigationDTO(
-                    "«",
-                    includeLimit
-                        ? String.format("limit=%d&offset=%d", transformationContext.getLimit(), 0)
-                        : String.format("offset=%d", 0)))
+                    "«", String.format("limit=%d&offset=%d", transformationContext.getLimit(), 0)))
             .add(
                 new NavigationDTO(
                     "‹",
-                    includeLimit
-                        ? String.format(
-                            "limit=%d&offset=%d",
-                            transformationContext.getLimit(),
-                            transformationContext.getOffset() - transformationContext.getLimit())
-                        : String.format(
-                            "offset=%d",
-                            transformationContext.getOffset() - transformationContext.getLimit())));
+                    String.format(
+                        "limit=%d&offset=%d",
+                        transformationContext.getLimit(),
+                        transformationContext.getOffset() - transformationContext.getLimit())));
         metaPagination.add(
             new NavigationDTO(
                 "prev",
-                includeLimit
-                    ? String.format(
-                        "limit=%d&offset=%d",
-                        transformationContext.getLimit(),
-                        transformationContext.getOffset() - transformationContext.getLimit())
-                    : String.format(
-                        "offset=%d",
-                        transformationContext.getOffset() - transformationContext.getLimit())));
+                String.format(
+                    "limit=%d&offset=%d",
+                    transformationContext.getLimit(),
+                    transformationContext.getOffset() - transformationContext.getLimit())));
       } else {
         pagination.add(new NavigationDTO("«")).add(new NavigationDTO("‹"));
       }
@@ -128,12 +122,10 @@ public class FeatureEncoderHtml extends FeatureObjectEncoder<PropertyHtml, Featu
             pagination.add(
                 new NavigationDTO(
                     String.valueOf(i),
-                    includeLimit
-                        ? String.format(
-                            "limit=%d&offset=%d",
-                            transformationContext.getLimit(),
-                            (i - 1) * transformationContext.getLimit())
-                        : String.format("&offset=%d", (i - 1) * transformationContext.getLimit())));
+                    String.format(
+                        "limit=%d&offset=%d",
+                        transformationContext.getLimit(),
+                        (i - 1) * transformationContext.getLimit())));
           }
         }
 
@@ -142,36 +134,24 @@ public class FeatureEncoderHtml extends FeatureObjectEncoder<PropertyHtml, Featu
               .add(
                   new NavigationDTO(
                       "›",
-                      includeLimit
-                          ? String.format(
-                              "limit=%d&offset=%d",
-                              transformationContext.getLimit(),
-                              transformationContext.getOffset() + transformationContext.getLimit())
-                          : String.format(
-                              "offset=%d",
-                              transformationContext.getOffset()
-                                  + transformationContext.getLimit())))
+                      String.format(
+                          "limit=%d&offset=%d",
+                          transformationContext.getLimit(),
+                          transformationContext.getOffset() + transformationContext.getLimit())))
               .add(
                   new NavigationDTO(
                       "»",
-                      includeLimit
-                          ? String.format(
-                              "limit=%d&offset=%d",
-                              transformationContext.getLimit(),
-                              (pages - 1) * transformationContext.getLimit())
-                          : String.format(
-                              "offset=%d", (pages - 1) * transformationContext.getLimit())));
+                      String.format(
+                          "limit=%d&offset=%d",
+                          transformationContext.getLimit(),
+                          (pages - 1) * transformationContext.getLimit())));
           metaPagination.add(
               new NavigationDTO(
                   "next",
-                  includeLimit
-                      ? String.format(
-                          "limit=%d&offset=%d",
-                          transformationContext.getLimit(),
-                          transformationContext.getOffset() + transformationContext.getLimit())
-                      : String.format(
-                          "offset=%d",
-                          transformationContext.getOffset() + transformationContext.getLimit())));
+                  String.format(
+                      "limit=%d&offset=%d",
+                      transformationContext.getLimit(),
+                      transformationContext.getOffset() + transformationContext.getLimit())));
         } else {
           pagination.add(new NavigationDTO("›")).add(new NavigationDTO("»"));
         }
@@ -195,25 +175,17 @@ public class FeatureEncoderHtml extends FeatureObjectEncoder<PropertyHtml, Featu
           pagination.add(
               new NavigationDTO(
                   "›",
-                  includeLimit
-                      ? String.format(
-                          "limit=%d&offset=%d",
-                          transformationContext.getLimit(),
-                          transformationContext.getOffset() + transformationContext.getLimit())
-                      : String.format(
-                          "offset=%d",
-                          transformationContext.getOffset() + transformationContext.getLimit())));
+                  String.format(
+                      "limit=%d&offset=%d",
+                      transformationContext.getLimit(),
+                      transformationContext.getOffset() + transformationContext.getLimit())));
           metaPagination.add(
               new NavigationDTO(
                   "next",
-                  includeLimit
-                      ? String.format(
-                          "limit=%d&offset=%d",
-                          transformationContext.getLimit(),
-                          transformationContext.getOffset() + transformationContext.getLimit())
-                      : String.format(
-                          "offset=%d",
-                          transformationContext.getOffset() + transformationContext.getLimit())));
+                  String.format(
+                      "limit=%d&offset=%d",
+                      transformationContext.getLimit(),
+                      transformationContext.getOffset() + transformationContext.getLimit())));
         } else {
           pagination.add(new NavigationDTO("›"));
         }

--- a/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/domain/FeatureEncoderHtml.java
+++ b/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/domain/FeatureEncoderHtml.java
@@ -57,10 +57,10 @@ public class FeatureEncoderHtml extends FeatureObjectEncoder<PropertyHtml, Featu
 
   @Override
   public void onStart(ModifiableContext context) {
-    // Query-expression responses (ad-hoc and stored queries) are single-shot: the 'limit'
-    // applies to the entire result set and offset-based paging is not supported (the endpoints
-    // reject 'limit'/'offset'), so no pagination or prev/next links are generated.
-    if (transformationContext.isQueryExpression()) {
+    // Single-shot responses (ad-hoc queries, and stored queries with supportPaging=false) are not
+    // paged, so no pagination controls are generated. Paged stored queries fall through and page by
+    // offset only (there is no 'limit' query parameter for stored queries).
+    if (!transformationContext.supportsPaging()) {
       return;
     }
 
@@ -86,23 +86,26 @@ public class FeatureEncoderHtml extends FeatureObjectEncoder<PropertyHtml, Featu
 
       ImmutableList.Builder<NavigationDTO> pagination = new ImmutableList.Builder<>();
       ImmutableList.Builder<NavigationDTO> metaPagination = new ImmutableList.Builder<>();
+      // query expressions page by offset only (no 'limit' query parameter); collections use both
+      String pageUrlFormat =
+          transformationContext.isQueryExpression() ? "offset=%2$d" : "limit=%1$d&offset=%2$d";
       if (transformationContext.getPage() > 1) {
         pagination
             .add(
                 new NavigationDTO(
-                    "«", String.format("limit=%d&offset=%d", transformationContext.getLimit(), 0)))
+                    "«", String.format(pageUrlFormat, transformationContext.getLimit(), 0)))
             .add(
                 new NavigationDTO(
                     "‹",
                     String.format(
-                        "limit=%d&offset=%d",
+                        pageUrlFormat,
                         transformationContext.getLimit(),
                         transformationContext.getOffset() - transformationContext.getLimit())));
         metaPagination.add(
             new NavigationDTO(
                 "prev",
                 String.format(
-                    "limit=%d&offset=%d",
+                    pageUrlFormat,
                     transformationContext.getLimit(),
                     transformationContext.getOffset() - transformationContext.getLimit())));
       } else {
@@ -123,7 +126,7 @@ public class FeatureEncoderHtml extends FeatureObjectEncoder<PropertyHtml, Featu
                 new NavigationDTO(
                     String.valueOf(i),
                     String.format(
-                        "limit=%d&offset=%d",
+                        pageUrlFormat,
                         transformationContext.getLimit(),
                         (i - 1) * transformationContext.getLimit())));
           }
@@ -135,21 +138,21 @@ public class FeatureEncoderHtml extends FeatureObjectEncoder<PropertyHtml, Featu
                   new NavigationDTO(
                       "›",
                       String.format(
-                          "limit=%d&offset=%d",
+                          pageUrlFormat,
                           transformationContext.getLimit(),
                           transformationContext.getOffset() + transformationContext.getLimit())))
               .add(
                   new NavigationDTO(
                       "»",
                       String.format(
-                          "limit=%d&offset=%d",
+                          pageUrlFormat,
                           transformationContext.getLimit(),
                           (pages - 1) * transformationContext.getLimit())));
           metaPagination.add(
               new NavigationDTO(
                   "next",
                   String.format(
-                      "limit=%d&offset=%d",
+                      pageUrlFormat,
                       transformationContext.getLimit(),
                       transformationContext.getOffset() + transformationContext.getLimit())));
         } else {
@@ -166,7 +169,7 @@ public class FeatureEncoderHtml extends FeatureObjectEncoder<PropertyHtml, Featu
                 new NavigationDTO(
                     String.valueOf(i),
                     String.format(
-                        "limit=%d&offset=%d",
+                        pageUrlFormat,
                         transformationContext.getLimit(),
                         (i - 1) * transformationContext.getLimit())));
           }
@@ -176,14 +179,14 @@ public class FeatureEncoderHtml extends FeatureObjectEncoder<PropertyHtml, Featu
               new NavigationDTO(
                   "›",
                   String.format(
-                      "limit=%d&offset=%d",
+                      pageUrlFormat,
                       transformationContext.getLimit(),
                       transformationContext.getOffset() + transformationContext.getLimit())));
           metaPagination.add(
               new NavigationDTO(
                   "next",
                   String.format(
-                      "limit=%d&offset=%d",
+                      pageUrlFormat,
                       transformationContext.getLimit(),
                       transformationContext.getOffset() + transformationContext.getLimit())));
         } else {

--- a/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/domain/FeaturesView.java
+++ b/ogcapi-stable/ogcapi-features-html/src/main/java/de/ii/ogcapi/features/html/domain/FeaturesView.java
@@ -11,6 +11,7 @@ import com.github.mustachejava.util.DecoratedCollection;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import de.ii.ogcapi.common.domain.OgcApiDatasetView;
+import de.ii.ogcapi.features.core.domain.FeatureQueryScope;
 import de.ii.ogcapi.features.core.domain.FeaturesCoreConfiguration;
 import de.ii.ogcapi.features.html.app.CesiumDataFeatures;
 import de.ii.ogcapi.features.html.app.CrsEditor;
@@ -155,8 +156,13 @@ public abstract class FeaturesView extends OgcApiDatasetView {
   }
 
   @Value.Derived
-  public boolean fromStoredQuery() {
-    return false;
+  public FeatureQueryScope queryScope() {
+    return FeatureQueryScope.COLLECTION;
+  }
+
+  @Value.Derived
+  public boolean isQueryExpression() {
+    return queryScope().isQueryExpression();
   }
 
   @Nullable
@@ -196,7 +202,7 @@ public abstract class FeaturesView extends OgcApiDatasetView {
               new ImmutableSource.Builder()
                   .type(TYPE.geojson)
                   .url(
-                      fromStoredQuery()
+                      isQueryExpression()
                           ? uriBuilder()
                               .removeParameters("f")
                               .ensureParameter("f", "json")
@@ -380,6 +386,11 @@ public abstract class FeaturesView extends OgcApiDatasetView {
   @Value.Derived
   @Override
   public Optional<String> getCanonicalUrl() {
+    // A transient ad-hoc query (POST) has no addressable resource to link to.
+    if (!queryScope().hasCanonicalResource()) {
+      return Optional.empty();
+    }
+
     if (!isCollection() && PersistentUri().isPresent()) return PersistentUri();
 
     URICustomizer canonicalUri = uriBuilder().copy().ensureNoTrailingSlash().clearParameters();

--- a/ogcapi-stable/ogcapi-features-html/src/test/groovy/de/ii/ogcapi/features/html/domain/FeaturesViewCanonicalUrlSpec.groovy
+++ b/ogcapi-stable/ogcapi-features-html/src/test/groovy/de/ii/ogcapi/features/html/domain/FeaturesViewCanonicalUrlSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.features.html.domain
+
+import de.ii.ogcapi.features.core.domain.FeatureQueryScope
+import spock.lang.Specification
+
+class FeaturesViewCanonicalUrlSpec extends Specification {
+
+    def "an ad-hoc query response suppresses the canonical (self) link"() {
+        given: "a feature-collection view for a transient ad-hoc query (POST, no addressable resource)"
+        def view = ModifiableFeatureCollectionView.create()
+                .setUri(URI.create("http://localhost:7080/foo/search"))
+                .setQueryScope(FeatureQueryScope.AD_HOC_QUERY)
+
+        expect: "no canonical link is offered"
+        view.getCanonicalUrl() == Optional.empty()
+    }
+
+    def "a stored query response keeps the canonical (self) link"() {
+        given: "a feature-collection view for a stored query (GET, addressable resource)"
+        def view = ModifiableFeatureCollectionView.create()
+                .setUri(URI.create("http://localhost:7080/foo/search/a-query?f=html"))
+                .setQueryScope(FeatureQueryScope.STORED_QUERY)
+
+        expect: "the canonical link is the resource URL without query parameters"
+        view.getCanonicalUrl() == Optional.of("http://localhost:7080/foo/search/a-query")
+    }
+
+    def "a regular collection response keeps the canonical (self) link"() {
+        given: "a feature-collection view for a collection (default scope)"
+        def view = ModifiableFeatureCollectionView.create()
+                .setUri(URI.create("http://localhost:7080/foo/collections/bar/items?f=html"))
+
+        expect: "the scope defaults to COLLECTION and the canonical link is retained"
+        view.queryScope() == FeatureQueryScope.COLLECTION
+        view.getCanonicalUrl() == Optional.of("http://localhost:7080/foo/collections/bar/items")
+    }
+}

--- a/ogcapi-stable/ogcapi-html/src/main/resources/de/ii/ogcapi/html/templates/feature.mustache
+++ b/ogcapi-stable/ogcapi-html/src/main/resources/de/ii/ogcapi/html/templates/feature.mustache
@@ -1,11 +1,11 @@
 <div>
     {{#inCollection}}
-      {{#fromStoredQuery}}
+      {{#isQueryExpression}}
         <h4 class="mt-3 mb-1"><span>{{name}}</span></h4>
-      {{/fromStoredQuery}}
-      {{^fromStoredQuery}}
+      {{/isQueryExpression}}
+      {{^isQueryExpression}}
         <h4 class="mt-3 mb-1"><a href="{{#currentUrlWithSegment}}{{idValue}}{{/currentUrlWithSegment}}{{additionalParams}}"><span>{{name}}</span></a></h4>
-      {{/fromStoredQuery}}
+      {{/isQueryExpression}}
       <span class="d-none">{{#currentUrlWithSegmentClearParams}}{{idValue}}{{/currentUrlWithSegmentClearParams}}</span>
     {{/inCollection}}
     {{^inCollection}}


### PR DESCRIPTION
### Pull request checklist

-   [x] Added/updated unit tests
-   [x] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

Follow-up to #1647.

Closes #906.

Depends on https://github.com/ldproxy/xtraplatform-spatial/pull/555.

I had second thoughts on removing paging entirely from the Search endpoints. The reasons are: stored queries in current APIs use paging and paging support is at the moment still expected in OGC API Features Part 10. Also, for relatively simple stored queries paging can be useful, so it probably also should be kept in the future. 

However, often stored queries will be most useful as a single-shot, in particular, if they are complex, involve many sub-queries and return large numbers of features.  The Search endpoint responses (ad-hoc and stored queries) are now **single-shot by default**: all matching features are returned in one pass, without `numberMatched`/`numberReturned`. This suits long-running query expressions with high limits and many sub-queries - and asynchronous processing (a capability to be added in a follow-up PR). 

#1647 had dropped paging from Search endpoints; this PR makes single-shot the explicit default and **re-introduces paging as an opt-in** for stored queries, where the result is an addressable resource via a GET request.

For ad-hoc queries, which use POST there is no GET-addressable resource and paging is not supported. This resolves the main issue in #906. `self` and `alternate` links were already dropped for ad-hoc queries - except in HTML (see below).

#### Single-shot vs. paged

- **Single-shot (default).** One pass over the whole result set: no meta queries, no `numberMatched` / `numberReturned`, no paging links. `limit` does not page; an optional server-side maximum (`maximumFeaturesPerQuery` in the SEARCH building-block configuration) bounds the response. A server-side cursor keeps memory bounded regardless of result size.
- **Paged — `supportPaging: true`, stored queries only.** Reports `numberMatched` / `numberReturned`, is retrievable page by page via the `offset` query parameter, and includes `prev`/`next`/`first` links and the HTML pagination bar. For a multi-query, `numberMatched` is the invariant total across **all** sub-queries, while value queries are executed only for the sub-queries needed for the page.
- **Ad-hoc queries (POST) are always single-shot.** A POST request produces a transient result with no addressable resource to page through, so an explicit `supportPaging: true` is rejected with a clear error.

#### Links and HTML

An ad-hoc query is submitted via POST with a JSON query expression and produces a transient result with no addressable resource on the server. Its HTML representation nevertheless advertised a canonical (`self`) link and an offset-based pagination bar pointing at GET URLs the POST-only endpoint rejects.

`FeatureQueryScope` — carried by the feature transformation context and routed from the query handler into the HTML view — distinguishes `COLLECTION`, `AD_HOC_QUERY`, `STORED_QUERY` (paged) and `STORED_QUERY_SINGLE_SHOT`, and derives:

- `supportsPaging` — pagination and `prev`/`next` links are shown only for paged responses (collections, and stored queries with `supportPaging: true`). Query-expression pagination URLs use `offset` only (there is no `limit` query parameter for stored queries).
- `hasCanonicalResource` — the `canonical`/`self` link is suppressed only for ad-hoc queries; a stored query is a real GETable resource and keeps its `canonical` and `alternate`-format links.

The body and `Link` header were already correct (no links for ad-hoc); this aligns the HTML representation with the other formats.

## Renamed properties

- Query expression: `computeNumberMatched` → `supportPaging` (the query-level flag). The provider-level `computeNumberMatched` option is unchanged and still controls whether the count is computed at all.
- View flag: `fromStoredQuery` → `isQueryExpression` — it was set for ad-hoc queries as well and is used to drop the per-feature title link and keep the map data CRS, both of which apply to any query expression. The `feature.mustache` token is renamed to match. `isQueryExpression` on the transformation context now derives from the scope instead of the presence of a query id; the search handler is the only producer of query-id-bearing feature responses and sets the scope.

## Behaviour change / migration

- The default for query expressions changes from counted to **single-shot**. A stored query that relied on the previous default and wants paging must set `supportPaging: true`.
- `computeNumberMatched` is no longer a query-expression member; replace it with `supportPaging` (`computeNumberMatched: false` → `supportPaging: false`; both are single-shot). The counted, page-by-page behaviour is now opt-in via `supportPaging: true`.
