### PR TITLE
crs: advertise all registered CRS URIs via EpsgCrs.allUris()

### DIFF
--- a/gradle/layers.versions.toml
+++ b/gradle/layers.versions.toml
@@ -1,5 +1,5 @@
 [versions]
 xtraplatform-core    = '7.0.0-SNAPSHOT'
 xtraplatform-native  = '2.6.0-SNAPSHOT'
-xtraplatform-spatial = '8.0.0-crs84-alias-uri-SNAPSHOT'
+xtraplatform-spatial = '8.0.0-SNAPSHOT'
 

--- a/gradle/layers.versions.toml
+++ b/gradle/layers.versions.toml
@@ -1,5 +1,5 @@
 [versions]
 xtraplatform-core    = '7.0.0-SNAPSHOT'
 xtraplatform-native  = '2.6.0-SNAPSHOT'
-xtraplatform-spatial = '8.0.0-SNAPSHOT'
+xtraplatform-spatial = '8.0.0-crs84-alias-uri-SNAPSHOT'
 

--- a/ogcapi-draft/ogcapi-routes/src/main/java/de/ii/ogcapi/routes/app/QueryParameterCrsRoutes.java
+++ b/ogcapi-draft/ogcapi-routes/src/main/java/de/ii/ogcapi/routes/app/QueryParameterCrsRoutes.java
@@ -36,7 +36,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Stream;
 
 /**
  * @title crs
@@ -129,9 +128,7 @@ public class QueryParameterCrsRoutes extends OgcApiQueryParameterBase
     if (!schemaMap.containsKey(apiHashCode)) {
       List<String> crsList =
           crsSupport.getSupportedCrsList(apiData).stream()
-              .flatMap(
-                  crs -> Stream.of(crs.toUriString(), crs.toAlternativeUriString().orElse(null)))
-              .filter(Objects::nonNull)
+              .flatMap(crs -> crs.allUris().stream())
               .collect(ImmutableList.toImmutableList());
       String defaultCrs =
           apiData

--- a/ogcapi-stable/ogcapi-crs/src/main/java/de/ii/ogcapi/crs/app/CrsOnCollection.java
+++ b/ogcapi-stable/ogcapi-crs/src/main/java/de/ii/ogcapi/crs/app/CrsOnCollection.java
@@ -25,9 +25,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 /** add CRS information to the collection information */
 @Singleton
@@ -76,9 +74,7 @@ public class CrsOnCollection implements CollectionExtension {
         // this is just the collection resource, so no default to reference; include all CRSs
         crsList =
             crsSupport.getSupportedCrsList(api.getData(), featureTypeConfiguration).stream()
-                .flatMap(
-                    crs -> Stream.of(crs.toUriString(), crs.toAlternativeUriString().orElse(null)))
-                .filter(Objects::nonNull)
+                .flatMap(crs -> crs.allUris().stream())
                 .collect(ImmutableList.toImmutableList());
       }
       collection.crs(crsList);

--- a/ogcapi-stable/ogcapi-crs/src/main/java/de/ii/ogcapi/crs/app/CrsOnCollections.java
+++ b/ogcapi-stable/ogcapi-crs/src/main/java/de/ii/ogcapi/crs/app/CrsOnCollections.java
@@ -22,9 +22,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 /**
  * add CRS information to the collection information (default list of coordinate reference systems)
@@ -63,10 +61,7 @@ public class CrsOnCollections implements CollectionsExtension {
                   .orElse(false)
               ? ImmutableList.of()
               : crsSupport.getSupportedCrsList(api.getData()).stream()
-                  .flatMap(
-                      crs ->
-                          Stream.of(crs.toUriString(), crs.toAlternativeUriString().orElse(null)))
-                  .filter(Objects::nonNull)
+                  .flatMap(crs -> crs.allUris().stream())
                   .collect(ImmutableList.toImmutableList());
 
       collectionsBuilder.crs(crsList);

--- a/ogcapi-stable/ogcapi-crs/src/main/java/de/ii/ogcapi/crs/app/QueryParameterBboxCrsFeatures.java
+++ b/ogcapi-stable/ogcapi-crs/src/main/java/de/ii/ogcapi/crs/app/QueryParameterBboxCrsFeatures.java
@@ -32,7 +32,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Stream;
 
 /**
  * @title bbox-crs
@@ -134,9 +133,7 @@ public class QueryParameterBboxCrsFeatures extends OgcApiQueryParameterBase
               .getSupportedCrsList(apiData, apiData.getCollections().get(collectionId))
               .stream()
               .map(crs -> crs.equals(OgcCrs.CRS84h) ? OgcCrs.CRS84 : crs)
-              .flatMap(
-                  crs -> Stream.of(crs.toUriString(), crs.toAlternativeUriString().orElse(null)))
-              .filter(Objects::nonNull)
+              .flatMap(crs -> crs.allUris().stream())
               .collect(ImmutableList.toImmutableList());
       schemaMap
           .get(apiHashCode)

--- a/ogcapi-stable/ogcapi-crs/src/main/java/de/ii/ogcapi/crs/app/QueryParameterCrsFeatures.java
+++ b/ogcapi-stable/ogcapi-crs/src/main/java/de/ii/ogcapi/crs/app/QueryParameterCrsFeatures.java
@@ -38,7 +38,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Stream;
 
 /**
  * @title crs
@@ -148,9 +147,7 @@ public class QueryParameterCrsFeatures extends OgcApiQueryParameterBase
           crsSupport
               .getSupportedCrsList(apiData, apiData.getCollections().get(collectionId))
               .stream()
-              .flatMap(
-                  crs -> Stream.of(crs.toUriString(), crs.toAlternativeUriString().orElse(null)))
-              .filter(Objects::nonNull)
+              .flatMap(crs -> crs.allUris().stream())
               .collect(ImmutableList.toImmutableList());
       String defaultCrs =
           apiData

--- a/ogcapi-stable/ogcapi-crs/src/main/java/de/ii/ogcapi/crs/domain/HeaderContentCrs.java
+++ b/ogcapi-stable/ogcapi-crs/src/main/java/de/ii/ogcapi/crs/domain/HeaderContentCrs.java
@@ -18,10 +18,8 @@ import de.ii.xtraplatform.crs.domain.OgcCrs;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Stream;
 
 /**
  * Shared base for the {@code Content-Crs} header. Provides the OpenAPI schema (an enum of the API's
@@ -52,10 +50,7 @@ public abstract class HeaderContentCrs extends ApiExtensionCache implements ApiH
         h -> {
           List<String> crsList =
               crsSupport.getSupportedCrsList(apiData).stream()
-                  .flatMap(
-                      crs ->
-                          Stream.of(crs.toUriString(), crs.toAlternativeUriString().orElse(null)))
-                  .filter(Objects::nonNull)
+                  .flatMap(crs -> crs.allUris().stream())
                   .map(HeaderContentCrs::toUriInHeader)
                   .collect(ImmutableList.toImmutableList());
           String defaultCrs =

--- a/ogcapi-stable/ogcapi-features-jsonfg/src/test/groovy/de/ii/ogcapi/features/jsonfg/app/JsonFgWriterCrsSpec.groovy
+++ b/ogcapi-stable/ogcapi-features-jsonfg/src/test/groovy/de/ii/ogcapi/features/jsonfg/app/JsonFgWriterCrsSpec.groovy
@@ -29,7 +29,7 @@ class JsonFgWriterCrsSpec extends Specification {
         boolean isCollection = true
         EpsgCrs crs = DEFAULT_CRS
         String expected = "{" + System.lineSeparator() +
-                "  \""+ JsonFgWriterCrs.JSON_KEY+"\" : \""+crs.toAlternativeUriString().get()+"\"" + System.lineSeparator() +
+                "  \""+ JsonFgWriterCrs.JSON_KEY+"\" : \""+OgcCrs.CRS84_URI_NEW+"\"" + System.lineSeparator() +
                 "}"
 
         when:
@@ -64,7 +64,7 @@ class JsonFgWriterCrsSpec extends Specification {
         boolean isCollection = false
         EpsgCrs crs = DEFAULT_CRS
         String expected = "{" + System.lineSeparator() +
-                "  \""+JsonFgWriterCrs.JSON_KEY+"\" : \""+crs.toAlternativeUriString().get()+"\"" + System.lineSeparator() +
+                "  \""+JsonFgWriterCrs.JSON_KEY+"\" : \""+OgcCrs.CRS84_URI_NEW+"\"" + System.lineSeparator() +
                 "}"
 
         when:

--- a/ogcapi-stable/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/api/QueryParameterFilterCrs.java
+++ b/ogcapi-stable/ogcapi-filter/src/main/java/de/ii/ogcapi/filter/api/QueryParameterFilterCrs.java
@@ -37,7 +37,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Stream;
 
 /**
  * @title filter-crs
@@ -171,9 +170,7 @@ public class QueryParameterFilterCrs extends OgcApiQueryParameterBase
           crsSupport
               .getSupportedCrsList(apiData, apiData.getCollections().get(collectionId))
               .stream()
-              .flatMap(
-                  crs -> Stream.of(crs.toUriString(), crs.toAlternativeUriString().orElse(null)))
-              .filter(Objects::nonNull)
+              .flatMap(crs -> crs.allUris().stream())
               .collect(ImmutableList.toImmutableList());
       crsListBuilder.addAll(crsList);
       if (!crsList.contains(CRS84)) crsListBuilder.add(CRS84);


### PR DESCRIPTION
### Pull request checklist

-   [x] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

Closes #1681.

Depends on https://github.com/ldproxy/xtraplatform-spatial/pull/567.

Adapts to the xtraplatform-spatial change that fixes the reported CRS identifier when the CRS84 alias URI (.../OGC/0/CRS84) is used in a request: EpsgCrs.toAlternativeUriString() has been replaced by EpsgCrs.allUris(), which lists all registered URIs of a CRS.

- Parameter/header schema enums (crs, bbox-crs, filter-crs, routes crs, Content-Crs) and the collection metadata crs arrays now use allUris() to advertise both CRS84 spellings.
- JSON-FG writer spec asserts the alias URI via the OgcCrs constant.

