### PR TITLE
profiles: scope profiles to the schema types they apply to

### DIFF
--- a/ogcapi-custom/ogcapi-collections-schema-validation/src/main/java/de/ii/ogcapi/collections/schema/validation/app/ProfileSetJsonSchemaForValidation.java
+++ b/ogcapi-custom/ogcapi-collections-schema-validation/src/main/java/de/ii/ogcapi/collections/schema/validation/app/ProfileSetJsonSchemaForValidation.java
@@ -17,6 +17,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.core.MediaType;
 import java.util.Optional;
+import java.util.Set;
 
 @Singleton
 @AutoBind
@@ -43,8 +44,8 @@ public class ProfileSetJsonSchemaForValidation extends ProfileSet {
   }
 
   @Override
-  public ResourceType getResourceType() {
-    return ResourceType.SCHEMA;
+  public Set<ResourceType> getResourceTypes() {
+    return Set.of(ResourceType.SCHEMA_RETURNABLES_AND_RECEIVABLES);
   }
 
   @Override

--- a/ogcapi-custom/ogcapi-profile-val/src/main/java/de/ii/ogcapi/profile/val/app/ProfileSetVal.java
+++ b/ogcapi-custom/ogcapi-profile-val/src/main/java/de/ii/ogcapi/profile/val/app/ProfileSetVal.java
@@ -19,6 +19,7 @@ import de.ii.xtraplatform.features.domain.SchemaConstraints;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.core.MediaType;
+import java.util.Set;
 
 @Singleton
 @AutoBind
@@ -34,8 +35,8 @@ public class ProfileSetVal extends ProfileSet {
   }
 
   @Override
-  public ResourceType getResourceType() {
-    return ResourceType.FEATURE;
+  public Set<ResourceType> getResourceTypes() {
+    return Set.of(ResourceType.FEATURE);
   }
 
   @Override

--- a/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/app/ProfileSetAll.java
+++ b/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/app/ProfileSetAll.java
@@ -15,6 +15,7 @@ import de.ii.ogcapi.foundation.domain.ProfileSet;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.core.MediaType;
+import java.util.Set;
 
 @Singleton
 @AutoBind
@@ -28,8 +29,8 @@ public class ProfileSetAll extends ProfileSet {
   }
 
   @Override
-  public ResourceType getResourceType() {
-    return ResourceType.FEATURE;
+  public Set<ResourceType> getResourceTypes() {
+    return Set.of(ResourceType.FEATURE);
   }
 
   @Override

--- a/ogcapi-draft/ogcapi-sorting/src/main/java/de/ii/ogcapi/sorting/app/QueryParameterProfileSortables.java
+++ b/ogcapi-draft/ogcapi-sorting/src/main/java/de/ii/ogcapi/sorting/app/QueryParameterProfileSortables.java
@@ -69,7 +69,7 @@ public class QueryParameterProfileSortables extends QueryParameterProfile
 
   @Override
   public ResourceType getResourceType() {
-    return ResourceType.SCHEMA;
+    return ResourceType.SCHEMA_SORTABLES;
   }
 
   @Override

--- a/ogcapi-draft/ogcapi-versioned-features/src/main/java/de/ii/ogcapi/versioned/features/app/ProfileSetVersions.java
+++ b/ogcapi-draft/ogcapi-versioned-features/src/main/java/de/ii/ogcapi/versioned/features/app/ProfileSetVersions.java
@@ -17,6 +17,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.core.MediaType;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Profile set {@code versions} for the Versioned Features building block. Carries the {@code
@@ -46,8 +47,8 @@ public class ProfileSetVersions extends ProfileSet {
   }
 
   @Override
-  public ResourceType getResourceType() {
-    return ResourceType.FEATURE;
+  public Set<ResourceType> getResourceTypes() {
+    return Set.of(ResourceType.FEATURE);
   }
 
   @Override

--- a/ogcapi-stable/ogcapi-collections-queryables/src/main/java/de/ii/ogcapi/collections/queryables/app/QueryParameterProfileQueryables.java
+++ b/ogcapi-stable/ogcapi-collections-queryables/src/main/java/de/ii/ogcapi/collections/queryables/app/QueryParameterProfileQueryables.java
@@ -69,7 +69,7 @@ public class QueryParameterProfileQueryables extends QueryParameterProfile
 
   @Override
   public ResourceType getResourceType() {
-    return ResourceType.SCHEMA;
+    return ResourceType.SCHEMA_QUERYABLES;
   }
 
   @Override

--- a/ogcapi-stable/ogcapi-collections-schema/src/main/java/de/ii/ogcapi/collections/schema/app/QueryParameterProfileSchema.java
+++ b/ogcapi-stable/ogcapi-collections-schema/src/main/java/de/ii/ogcapi/collections/schema/app/QueryParameterProfileSchema.java
@@ -68,7 +68,7 @@ public class QueryParameterProfileSchema extends QueryParameterProfile implement
 
   @Override
   public ResourceType getResourceType() {
-    return ResourceType.SCHEMA;
+    return ResourceType.SCHEMA_RETURNABLES_AND_RECEIVABLES;
   }
 
   @Override

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ogcapi/common/domain/QueryParameterProfile.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ogcapi/common/domain/QueryParameterProfile.java
@@ -125,7 +125,8 @@ public abstract class QueryParameterProfile extends OgcApiQueryParameterBase
     return extensionRegistry.getExtensionsForType(ProfileSet.class).stream()
         .filter(
             profileSet ->
-                profileSet.isEnabledForApi(apiData) && profileSet.getResourceType() == resourceType)
+                profileSet.isEnabledForApi(apiData)
+                    && profileSet.getResourceTypes().contains(resourceType))
         .map(profileSet -> profileSet.getProfiles(apiData, Optional.empty()))
         .flatMap(List::stream)
         .collect(Collectors.toList());
@@ -137,8 +138,7 @@ public abstract class QueryParameterProfile extends OgcApiQueryParameterBase
         .filter(
             profileSet ->
                 profileSet.isEnabledForApi(apiData, collectionId)
-                    && profileSet.getResourceType() == resourceType)
-        .filter(profileSet -> profileSet.isEnabledForApi(apiData, collectionId))
+                    && profileSet.getResourceTypes().contains(resourceType))
         .map(profileSet -> profileSet.getProfiles(apiData, Optional.of(collectionId)))
         .flatMap(List::stream)
         .collect(Collectors.toList());

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/FeaturesCoreQueriesHandlerImpl.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/FeaturesCoreQueriesHandlerImpl.java
@@ -286,6 +286,7 @@ public class FeaturesCoreQueriesHandlerImpl extends AbstractVolatileComposed
     Map<ApiMediaType, List<Profile>> alternateProfiles =
         getAlternateProfiles(
             allProfileSets,
+            ResourceType.FEATURE,
             api.getData(),
             collectionId,
             requestContext.getMediaType(),

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/QueriesHandlerSchemaFeatures.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/QueriesHandlerSchemaFeatures.java
@@ -93,6 +93,17 @@ public class QueriesHandlerSchemaFeatures extends AbstractVolatileComposed
     return queryHandlers;
   }
 
+  private static ResourceType getResourceType(SchemaType type) {
+    return switch (type) {
+      case RETURNABLES_AND_RECEIVABLES -> ResourceType.SCHEMA_RETURNABLES_AND_RECEIVABLES;
+      case QUERYABLES -> ResourceType.SCHEMA_QUERYABLES;
+      case SORTABLES -> ResourceType.SCHEMA_SORTABLES;
+      case STORED_QUERY_PARAMETER ->
+          throw new IllegalStateException(
+              "No profiles are supported for stored query parameter schemas.");
+    };
+  }
+
   public static void checkCollectionId(OgcApiDataV2 apiData, String collectionId) {
     if (!apiData.isCollectionEnabled(collectionId)) {
       throw new NotFoundException(
@@ -125,11 +136,13 @@ public class QueriesHandlerSchemaFeatures extends AbstractVolatileComposed
 
     List<ProfileSet> allProfileSets = extensionRegistry.getExtensionsForType(ProfileSet.class);
 
+    ResourceType resourceType = getResourceType(type);
+
     List<Profile> profiles =
         negotiateProfiles(
             allProfileSets,
             outputFormat,
-            ResourceType.SCHEMA,
+            resourceType,
             apiData,
             Optional.of(collectionId),
             queryInput.getProfiles(),
@@ -138,6 +151,7 @@ public class QueriesHandlerSchemaFeatures extends AbstractVolatileComposed
     Map<ApiMediaType, List<Profile>> alternateProfiles =
         getAlternateProfiles(
             allProfileSets,
+            resourceType,
             apiData,
             collectionId,
             requestContext.getMediaType(),

--- a/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ogcapi/features/geojson/domain/ProfileSetGeoJson.java
+++ b/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ogcapi/features/geojson/domain/ProfileSetGeoJson.java
@@ -16,6 +16,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.core.MediaType;
 import java.util.Optional;
+import java.util.Set;
 
 @Singleton
 @AutoBind
@@ -42,8 +43,8 @@ public class ProfileSetGeoJson extends ProfileSet {
   }
 
   @Override
-  public ResourceType getResourceType() {
-    return ResourceType.FEATURE;
+  public Set<ResourceType> getResourceTypes() {
+    return Set.of(ResourceType.FEATURE);
   }
 
   @Override

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ProfileExtension.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ProfileExtension.java
@@ -13,6 +13,7 @@ import de.ii.xtraplatform.features.domain.profile.ImmutableProfileTransformation
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * The following types of profile extensions are distinguished:
@@ -32,7 +33,12 @@ public interface ProfileExtension extends ApiExtension {
 
   enum ResourceType {
     FEATURE,
-    SCHEMA
+    SCHEMA_RETURNABLES_AND_RECEIVABLES,
+    SCHEMA_QUERYABLES,
+    SCHEMA_SORTABLES;
+
+    public static final Set<ResourceType> ALL_SCHEMAS =
+        Set.of(SCHEMA_RETURNABLES_AND_RECEIVABLES, SCHEMA_QUERYABLES, SCHEMA_SORTABLES);
   }
 
   /**
@@ -47,7 +53,10 @@ public interface ProfileExtension extends ApiExtension {
     return String.format("http://www.opengis.net/def/profile/ogc/0/%s", profile.getId());
   }
 
-  ResourceType getResourceType();
+  /**
+   * @return the resource types to which the profiles of the profile extension apply
+   */
+  Set<ResourceType> getResourceTypes();
 
   /**
    * @return the id of the profile extension

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ProfileSet.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ProfileSet.java
@@ -66,7 +66,7 @@ public abstract class ProfileSet implements ProfileExtension {
     MediaType responseMediaType =
         outputFormat != null ? outputFormat.getMediaType().type() : MediaType.WILDCARD_TYPE;
     if ((Objects.nonNull(mediaType) && !mediaType.isCompatible(responseMediaType))
-        || !getResourceType().equals(resourceType)
+        || !getResourceTypes().contains(resourceType)
         || !collectionId
             .map(cid -> isEnabledForApi(apiData, cid))
             .orElse(isEnabledForApi(apiData))) {

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/QueriesHandler.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/QueriesHandler.java
@@ -346,6 +346,7 @@ public interface QueriesHandler<T extends QueryIdentifier> {
 
   default Map<ApiMediaType, List<Profile>> getAlternateProfiles(
       List<ProfileSet> allProfileSets,
+      ResourceType resourceType,
       OgcApiDataV2 apiData,
       String collectionId,
       ApiMediaType mediaType,
@@ -353,6 +354,7 @@ public interface QueriesHandler<T extends QueryIdentifier> {
       List<Profile> profiles) {
     return allProfileSets.stream()
         .filter(ProfileExtension::includeAlternateLinks)
+        .filter(profileSet -> profileSet.getResourceTypes().contains(resourceType))
         .filter(
             profileSet ->
                 mediaType.type().equals(profileSet.getMediaType())

--- a/ogcapi-stable/ogcapi-profile-codelist/src/main/java/de/ii/ogcapi/profile/codelist/app/ProfileSetCodelist.java
+++ b/ogcapi-stable/ogcapi-profile-codelist/src/main/java/de/ii/ogcapi/profile/codelist/app/ProfileSetCodelist.java
@@ -19,6 +19,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.core.MediaType;
 import java.util.Optional;
+import java.util.Set;
 
 @Singleton
 @AutoBind
@@ -50,8 +51,8 @@ public class ProfileSetCodelist extends ProfileSet {
   }
 
   @Override
-  public ResourceType getResourceType() {
-    return ResourceType.SCHEMA;
+  public Set<ResourceType> getResourceTypes() {
+    return ResourceType.ALL_SCHEMAS;
   }
 
   @Override

--- a/ogcapi-stable/ogcapi-profile-rel/src/main/java/de/ii/ogcapi/profile/rel/app/ProfileSetRel.java
+++ b/ogcapi-stable/ogcapi-profile-rel/src/main/java/de/ii/ogcapi/profile/rel/app/ProfileSetRel.java
@@ -21,6 +21,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.core.MediaType;
 import java.util.List;
+import java.util.Set;
 
 @Singleton
 @AutoBind
@@ -36,8 +37,8 @@ public class ProfileSetRel extends ProfileSet implements ConformanceClass {
   }
 
   @Override
-  public ResourceType getResourceType() {
-    return ResourceType.FEATURE;
+  public Set<ResourceType> getResourceTypes() {
+    return Set.of(ResourceType.FEATURE);
   }
 
   @Override

--- a/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TilesQueriesHandlerImpl.java
+++ b/ogcapi-stable/ogcapi-tiles/src/main/java/de/ii/ogcapi/tiles/app/TilesQueriesHandlerImpl.java
@@ -978,7 +978,7 @@ public class TilesQueriesHandlerImpl extends AbstractVolatileComposed
           negotiateProfiles(
               allProfileSets,
               null,
-              ResourceType.SCHEMA,
+              ResourceType.SCHEMA_RETURNABLES_AND_RECEIVABLES,
               apiData,
               collectionId,
               List.of(),


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

The resource type of a profile extension only distinguished FEATURE and SCHEMA, so profiles that are only meaningful for the schemas of returnables and receivables - like the JSON Schema validation profiles - were also offered and negotiated on the queryables and sortables schemas.

The resource types are now FEATURE, SCHEMA_RETURNABLES_AND_RECEIVABLES, SCHEMA_QUERYABLES and SCHEMA_SORTABLES, and each profile extension declares the set of resource types to which its profiles apply:

- the JSON Schema validation profiles apply only to the schema of returnables and receivables;
- the codelist profiles apply to all schema variants;
- the feature profile sets are unchanged (FEATURE only).

The schema queries handler maps the requested schema type to the matching resource type, the profile query parameters on the schema, queryables and sortables resources declare their concrete resource type, and alternate-profile links are now also filtered by resource type. Tileset vector schemas are treated as returnables/receivables schemas.
