### PR TITLE
landing page: show the aggregated number of features of all collections

### DIFF
--- a/ogcapi-custom/ogcapi-additional-metadata/src/main/java/de/ii/ogcapi/additional/metadata/app/AdditionalMetadataBuildingBlock.java
+++ b/ogcapi-custom/ogcapi-additional-metadata/src/main/java/de/ii/ogcapi/additional/metadata/app/AdditionalMetadataBuildingBlock.java
@@ -19,10 +19,13 @@ import jakarta.inject.Singleton;
  * @langEn Additional metadata on Landing Page, Collections an Collection resources.
  * @langDe Zusätzliche Metadaten auf den Ressourcen Landing Page, Collections und Collection.
  * @scopeEn Adds additional information to the Landing Page, Collections and Collection resources
- *     that is not specified in OGC API standards. For example, license and attribution information.
+ *     that is not specified in OGC API standards. For example, license and attribution information
+ *     as well as the aggregated spatial and temporal extents and the aggregated number of features
+ *     of all collections on the Landing Page.
  * @scopeDe Fügt der Landing Page, den Collections- und Collection-Ressourcen zusätzliche
  *     Informationen hinzu, die nicht in den OGC-API-Standards festgelegt sind. Zum Beispiel die
- *     Lizenz der Daten und Vorgaben zur Namensnennung.
+ *     Lizenz der Daten und Vorgaben zur Namensnennung sowie auf der Landing Page die aggregierte
+ *     räumliche und zeitliche Ausdehnung und die aggregierte Anzahl der Features aller Collections.
  * @ref:cfg {@link de.ii.ogcapi.additional.metadata.domain.AdditionalMetadataConfiguration}
  * @ref:cfgProperties {@link
  *     de.ii.ogcapi.additional.metadata.domain.ImmutableAdditionalMetadataConfiguration}

--- a/ogcapi-custom/ogcapi-additional-metadata/src/main/java/de/ii/ogcapi/additional/metadata/app/MetadataOnLandingPage.java
+++ b/ogcapi-custom/ogcapi-additional-metadata/src/main/java/de/ii/ogcapi/additional/metadata/app/MetadataOnLandingPage.java
@@ -65,6 +65,10 @@ public class MetadataOnLandingPage implements LandingPageExtension {
 
       OgcApiExtent.of(api.getSpatialExtent(), api.getTemporalExtent())
           .ifPresent(extent -> landingPageBuilder.putExtensions("extent", extent));
+
+      api.getItemCount()
+          .filter(count -> count >= 0)
+          .ifPresent(count -> landingPageBuilder.putExtensions("itemCount", count));
     }
 
     return landingPageBuilder;

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ogcapi/common/app/html/LandingPageFormatHtml.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ogcapi/common/app/html/LandingPageFormatHtml.java
@@ -108,6 +108,11 @@ public class LandingPageFormatHtml
                     apiLandingPage.getExtensions().containsKey("extent")
                         ? (OgcApiExtent) apiLandingPage.getExtensions().get("extent")
                         : null))
+            .itemCount(
+                Optional.ofNullable(
+                    apiLandingPage.getExtensions().containsKey("itemCount")
+                        ? (Long) apiLandingPage.getExtensions().get("itemCount")
+                        : null))
             .language(requestContext.getLanguage())
             .user(requestContext.getUser())
             .build();

--- a/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ogcapi/common/app/html/OgcApiLandingPageView.java
+++ b/ogcapi-stable/ogcapi-common/src/main/java/de/ii/ogcapi/common/app/html/OgcApiLandingPageView.java
@@ -36,6 +36,8 @@ public abstract class OgcApiLandingPageView extends OgcApiDatasetView {
 
   public abstract Optional<String> dataSourceUrl();
 
+  public abstract Optional<Long> itemCount();
+
   @Value.Derived
   public String mainLinksTitle() {
     return i18n().get("mainLinksTitle", language());
@@ -106,6 +108,11 @@ public abstract class OgcApiLandingPageView extends OgcApiDatasetView {
   @Value.Derived
   public String temporalExtentTitle() {
     return i18n().get("temporalExtentTitle", language());
+  }
+
+  @Value.Derived
+  public String itemCountTitle() {
+    return i18n().get("itemCountTitle", language());
   }
 
   @Value.Derived

--- a/ogcapi-stable/ogcapi-common/src/main/resources/de/ii/ogcapi/common/templates/landingPage.mustache
+++ b/ogcapi-stable/ogcapi-common/src/main/resources/de/ii/ogcapi/common/templates/landingPage.mustache
@@ -164,6 +164,19 @@
         </div>
     {{/temporalCoverageHtml}}
 
+    {{#itemCount}}
+        <div class="row my-3">
+            <div class="col-md-2 font-weight-bold">{{itemCountTitle}}</div>
+            <div class="col-md-10">
+                <ul class="list-unstyled">
+                    <li>
+                        <span id="itemCount">{{.}}</span>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    {{/itemCount}}
+
     <h2>{{expertInformationTitle}}</h2>
 
     <div class="row my-3">


### PR DESCRIPTION
### Pull request checklist

-   [x] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

Closes #1698

- ADDITIONAL_METADATA adds the aggregated item count to the landing page next to the aggregated spatial and temporal extents (JSON via the extensions map, HTML as a row after the temporal extent)
- reuses the existing `itemCountTitle` i18n key from the collection pages

