### PR TITLE
fix 500 response for an invalid value of a queryable query parameter

### DIFF
--- a/ogcapi-stable/ogcapi-collections-queryables/src/main/java/de/ii/ogcapi/collections/queryables/domain/QueryParameterTemplateQueryable.java
+++ b/ogcapi-stable/ogcapi-collections-queryables/src/main/java/de/ii/ogcapi/collections/queryables/domain/QueryParameterTemplateQueryable.java
@@ -23,6 +23,7 @@ import de.ii.xtraplatform.cql.domain.AContains;
 import de.ii.xtraplatform.cql.domain.ArrayLiteral;
 import de.ii.xtraplatform.cql.domain.BooleanValue2;
 import de.ii.xtraplatform.cql.domain.Cql2Expression;
+import de.ii.xtraplatform.cql.domain.CqlParseException;
 import de.ii.xtraplatform.cql.domain.Eq;
 import de.ii.xtraplatform.cql.domain.Function;
 import de.ii.xtraplatform.cql.domain.Like;
@@ -117,38 +118,46 @@ public abstract class QueryParameterTemplateQueryable extends OgcApiQueryParamet
       return null;
     }
 
-    // handle array case
-    if (getType() == Type.VALUE_ARRAY) {
-      if (value.contains("*")) {
-        return Function.of(
-            "ALIKE",
-            ImmutableList.of(
-                Property.of(getName()), ScalarLiteral.of(value.replaceAll("\\*", "%"))));
-      }
-      return AContains.of(
-          Property.of(getName()),
-          ArrayLiteral.of(
-              ARRAY_SPLITTER.splitToList(value).stream()
-                  .map(s -> getScalarLiteral(s, getValueType().orElse(Type.STRING)))
-                  .collect(Collectors.toUnmodifiableList())));
-    }
-
-    Type t = getValueType().orElse(getType());
-    switch (t) {
-      case INTEGER:
-      case FLOAT:
-      case BOOLEAN:
-        return Eq.of(getName(), getScalarLiteral(value, t));
-      case STRING:
+    try {
+      // handle array case
+      if (getType() == Type.VALUE_ARRAY) {
         if (value.contains("*")) {
-          return Like.of(getName(), ScalarLiteral.of(value.replaceAll("\\*", "%")));
+          return Function.of(
+              "ALIKE",
+              ImmutableList.of(
+                  Property.of(getName()), ScalarLiteral.of(value.replaceAll("\\*", "%"))));
         }
-        return Eq.of(getName(), ScalarLiteral.of(value));
-      case DATE:
-      case DATETIME:
-        return Eq.of(getName(), TemporalLiteral.of(value));
-      default:
-        return BooleanValue2.of(false);
+        return AContains.of(
+            Property.of(getName()),
+            ArrayLiteral.of(
+                ARRAY_SPLITTER.splitToList(value).stream()
+                    .map(s -> getScalarLiteral(s, getValueType().orElse(Type.STRING)))
+                    .collect(Collectors.toUnmodifiableList())));
+      }
+
+      Type t = getValueType().orElse(getType());
+      switch (t) {
+        case INTEGER:
+        case FLOAT:
+        case BOOLEAN:
+          return Eq.of(getName(), getScalarLiteral(value, t));
+        case STRING:
+          if (value.contains("*")) {
+            return Like.of(getName(), ScalarLiteral.of(value.replaceAll("\\*", "%")));
+          }
+          return Eq.of(getName(), ScalarLiteral.of(value));
+        case DATE:
+        case DATETIME:
+          return Eq.of(getName(), TemporalLiteral.of(value));
+        default:
+          return BooleanValue2.of(false);
+      }
+    } catch (CqlParseException | NumberFormatException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "The parameter '%s' is invalid: '%s' is not a valid value (%s).",
+              getName(), value, e.getMessage()),
+          e);
     }
   }
 

--- a/ogcapi-stable/ogcapi-collections-queryables/src/test/groovy/de/ii/ogcapi/collections/queryables/domain/QueryParameterTemplateQueryableSpec.groovy
+++ b/ogcapi-stable/ogcapi-collections-queryables/src/test/groovy/de/ii/ogcapi/collections/queryables/domain/QueryParameterTemplateQueryableSpec.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.collections.queryables.domain
+
+import de.ii.ogcapi.foundation.domain.SchemaValidator
+import de.ii.xtraplatform.cql.domain.Eq
+import de.ii.xtraplatform.features.domain.SchemaBase
+import io.swagger.v3.oas.models.media.StringSchema
+import spock.lang.Specification
+
+class QueryParameterTemplateQueryableSpec extends Specification {
+
+    def queryable(SchemaBase.Type type) {
+        return new ImmutableQueryParameterTemplateQueryable.Builder()
+                .apiId("api")
+                .collectionId("collection")
+                .name("lzi.end")
+                .description("a queryable")
+                .schema(new StringSchema())
+                .schemaValidator({ schema, value -> Optional.empty() } as SchemaValidator)
+                .type(type)
+                .build()
+    }
+
+    def 'invalid temporal value raises a client error, not a CQL parse error'() {
+        given:
+        def parameter = queryable(SchemaBase.Type.DATETIME)
+
+        when:
+        parameter.parse("*", [:], null, Optional.empty())
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("lzi.end")
+        e.message.contains("*")
+    }
+
+    def 'valid temporal value parses to an equality expression'() {
+        given:
+        def parameter = queryable(SchemaBase.Type.DATETIME)
+
+        when:
+        def result = parameter.parse("2026-02-17T17:38:11Z", [:], null, Optional.empty())
+
+        then:
+        result instanceof Eq
+    }
+
+    def 'invalid numeric value raises a client error'() {
+        given:
+        def parameter = queryable(SchemaBase.Type.INTEGER)
+
+        when:
+        parameter.parse("abc", [:], null, Optional.empty())
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+}


### PR DESCRIPTION
### Pull request checklist

-   [x] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

- map `CqlParseException` and `NumberFormatException` raised while parsing the value of a queryable query parameter (e.g. an invalid instant or number) to `IllegalArgumentException` so that the API returns a 400 with a helpful message instead of a 500
- add a unit test for the parameter parsing
