### PR TITLE
fix profile URIs

### DIFF
--- a/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/app/CommandHandlerCrudImpl.java
+++ b/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/app/CommandHandlerCrudImpl.java
@@ -555,7 +555,7 @@ public class CommandHandlerCrudImpl extends AbstractVolatileComposed implements 
                 .map(
                     url ->
                         extensionRegistry.getExtensionsForType(Profile.class).stream()
-                            .filter(p -> url.equals(ProfileExtension.getUri(p)))
+                            .filter(p -> url.equalsIgnoreCase(ProfileExtension.getUri(p)))
                             .findFirst())
                 .filter(Optional::isPresent)
                 .map(Optional::get)

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ProfileExtension.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ProfileExtension.java
@@ -46,11 +46,12 @@ public interface ProfileExtension extends ApiExtension {
    */
   static String getUri(Profile profile) {
     if (profile.getId().startsWith("val-")
+        || profile.getId().startsWith("crs-")
         || profile.getId().startsWith("all-")
         || profile.getId().startsWith("validation-")) {
       return String.format("https://def.ldproxy.net/profile/%s", profile.getId());
     }
-    return String.format("http://www.opengis.net/def/profile/ogc/0/%s", profile.getId());
+    return String.format("http://www.opengis.net/def/profile/OGC/0/%s", profile.getId());
   }
 
   /**


### PR DESCRIPTION
### Pull request checklist

-   [ ] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

OGC profile URIs from OGC API Features Part 5 and JSON-FG have "OGC" as the organization, not "ogc". At the same time, be more lenient in the URI comparison and ignore the case in comparisons.