### PR TITLE
transactions: option to collect all errors in atomic transactions

### DIFF
--- a/gradle/layers.versions.toml
+++ b/gradle/layers.versions.toml
@@ -1,5 +1,5 @@
 [versions]
 xtraplatform-core    = '7.0.0-SNAPSHOT'
 xtraplatform-native  = '2.6.0-SNAPSHOT'
-xtraplatform-spatial = '8.0.0-tx-savepoints-SNAPSHOT'
+xtraplatform-spatial = '8.0.0-SNAPSHOT'
 

--- a/gradle/layers.versions.toml
+++ b/gradle/layers.versions.toml
@@ -1,5 +1,5 @@
 [versions]
 xtraplatform-core    = '7.0.0-SNAPSHOT'
 xtraplatform-native  = '2.6.0-SNAPSHOT'
-xtraplatform-spatial = '8.0.0-SNAPSHOT'
+xtraplatform-spatial = '8.0.0-tx-savepoints-SNAPSHOT'
 

--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/CommandHandlerTransactionsImpl.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/CommandHandlerTransactionsImpl.java
@@ -31,7 +31,9 @@ import jakarta.inject.Singleton;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
@@ -194,7 +196,7 @@ public class CommandHandlerTransactionsImpl extends AbstractVolatileComposed
     int status = (atomic && failed) ? 422 : 200;
     String preferenceApplied = preferenceApplied(ret, handling);
 
-    if (ret == HeaderPrefer.Return.NONE && !failed && result.getWarnings().isEmpty()) {
+    if (ret == HeaderPrefer.Return.NONE && !failed && collectWarnings(result).isEmpty()) {
       return Response.noContent().header("Preference-Applied", preferenceApplied).build();
     }
 
@@ -224,6 +226,9 @@ public class CommandHandlerTransactionsImpl extends AbstractVolatileComposed
     summary.put("totalReplaced", result.getReplacedCount());
     summary.put("totalUpdated", result.getUpdatedCount());
     summary.put("totalDeleted", result.getDeletedCount());
+    summary.put("totalFailed", result.getFailedCount());
+    summary.put("totalRolledBack", result.getRolledBackCount());
+    summary.put("totalSkipped", result.getSkippedCount());
 
     ArrayNode insertResults = body.putArray("insertResults");
     ArrayNode replaceResults = body.putArray("replaceResults");
@@ -252,14 +257,43 @@ public class CommandHandlerTransactionsImpl extends AbstractVolatileComposed
       body.remove("deleteResults");
     }
 
+    result
+        .getTransactionError()
+        .ifPresent(error -> exceptions.add(renderTransactionException(error)));
+
     if (!exceptions.isEmpty()) {
       body.set("exceptions", exceptions);
     }
-    if (!result.getWarnings().isEmpty()) {
+    List<String> allWarnings = collectWarnings(result);
+    if (!allWarnings.isEmpty()) {
       ArrayNode warnings = body.putArray("warnings");
-      result.getWarnings().forEach(warnings::add);
+      allWarnings.forEach(warnings::add);
     }
     return body;
+  }
+
+  /**
+   * Transaction-level hook warnings plus the per-action SQL warnings, the latter prefixed with the
+   * action label so they stay attributable without a schema change to the response.
+   */
+  private static List<String> collectWarnings(ExecutionResult result) {
+    List<String> all = new ArrayList<>(result.getWarnings());
+    for (ActionResult r : result.getActionResults()) {
+      if (r.getWarnings().isEmpty()) {
+        continue;
+      }
+      String label =
+          r.getActionId()
+              .orElseGet(
+                  () ->
+                      r.getType().toString().toLowerCase(java.util.Locale.ROOT)
+                          + "@"
+                          + r.getCollectionId());
+      for (String w : r.getWarnings()) {
+        all.add("action " + label + ": " + w);
+      }
+    }
+    return all;
   }
 
   private static void addExceptionsFor(ActionResult r, ArrayNode exceptions) {
@@ -308,6 +342,19 @@ public class CommandHandlerTransactionsImpl extends AbstractVolatileComposed
       ArrayNode payloads = ex.putArray("featurePayloads");
       payloads.add(featurePayload);
     }
+    return ex;
+  }
+
+  /**
+   * A failure of the transaction as a whole (pre-commit hook or commit), not attributable to a
+   * single action — rendered without action-level fields.
+   */
+  private static ObjectNode renderTransactionException(String error) {
+    ObjectNode ex = MAPPER.createObjectNode();
+    ex.put("type", "about:blank");
+    ex.put("title", "Transaction failed");
+    ex.put("status", 422);
+    ex.put("detail", error);
     return ex;
   }
 

--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/TransactionExecutorImpl.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/TransactionExecutorImpl.java
@@ -160,14 +160,32 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
    * @param preCommit {@code true} for the pre-commit hook, {@code false} for the setup hook
    */
   private static List<String> hookStatements(
-      OgcApi api, HeaderPrefer.Handling handling, boolean preCommit) {
-    TransactionsConfiguration cfg =
-        api.getData().getExtension(TransactionsConfiguration.class).orElse(null);
+      TransactionsConfiguration cfg, HeaderPrefer.Handling handling, boolean preCommit) {
     if (cfg == null) {
       return List.of();
     }
     TransactionHooks hooks = preCommit ? cfg.getPreCommit() : cfg.getTransactionSetup();
     return hooks == null ? List.of() : hooks.effective(handling);
+  }
+
+  // Package-private (rather than private) so specs can swap the API-configuration and
+  // provider/session resolution out via an anonymous subclass — mocking the full OgcApi /
+  // FeatureProvider graph drags in classes that aren't on the test classpath (see
+  // resolveChanges).
+  TransactionsConfiguration transactionsConfig(OgcApi api) {
+    return api.getData().getExtension(TransactionsConfiguration.class).orElse(null);
+  }
+
+  String resolveProviderId(OgcApi api, String collectionId) {
+    return resolveProvider(api, collectionId).getId();
+  }
+
+  String canonicalCollectionId(OgcApi api, String collectionId) {
+    return canonicalCollectionId(api.getData(), collectionId);
+  }
+
+  Session openSessionFor(OgcApi api, String collectionId) {
+    return openSession(resolveProvider(api, collectionId), collectionId);
   }
 
   /**
@@ -199,8 +217,13 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
       Optional<Instant> ogcMutationDatetime) {
     // handling=strict turns on per-payload schema validation before any write.
     boolean validate = handling == HeaderPrefer.Handling.STRICT;
-    List<String> setup = hookStatements(api, handling, false);
-    List<String> preCommit = hookStatements(api, handling, true);
+    TransactionsConfiguration cfg = transactionsConfig(api);
+    List<String> setup = hookStatements(cfg, handling, false);
+    List<String> preCommit = hookStatements(cfg, handling, true);
+    // collectErrors: keep executing after a failed action so the response reports every error.
+    // Each action then runs inside a savepoint — after a failed SQL statement the shared
+    // transaction is only usable again once the action's writes are rolled back to it.
+    boolean collectErrors = cfg != null && Boolean.TRUE.equals(cfg.getCollectErrors());
     List<String> warnings = new ArrayList<>();
     // Single timestamp for the whole atomic transaction — every action shares it so versioned
     // strategies can reject same-feature chains under the no-backdating rule.
@@ -215,32 +238,46 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
     // MutationStrategy resolved once per (transaction, collectionId); the lookup walks every
     // registered strategy and is cheap but not free.
     Map<String, MutationStrategy> strategyByCollection = new LinkedHashMap<>();
-    Throwable firstError = null;
+    // A fatal error leaves a session unusable (failed open, setup hook, or savepoint handling)
+    // and always stops execution; a failed action only stops it when errors are not collected.
+    Throwable fatalError = null;
+    boolean anyFailed = false;
 
     Iterator<TxAction> actions = transaction.actions();
     while (actions.hasNext()) {
       TxAction action = actions.next();
-      if (firstError != null) {
-        // a previous action already failed — atomic semantics: skip remaining actions but
-        // still drain insert items so the parser stays in a consistent state
+      if (fatalError != null || (anyFailed && !collectErrors)) {
+        // execution has stopped — skip remaining actions but still drain insert items so the
+        // parser stays in a consistent state
         drainQuietly(action);
-        results.add(skipped(action));
+        results.add(skipped(canonicalCollectionId(api, action.getCollectionId()), action));
         continue;
       }
+      ActionResult result = null;
       try {
-        FeatureProvider provider = resolveProvider(api, action.getCollectionId());
-        Session session = sessionsByProvider.get(provider.getId());
+        String providerId = resolveProviderId(api, action.getCollectionId());
+        Session session = sessionsByProvider.get(providerId);
         if (session == null) {
-          session = openSession(provider, action.getCollectionId());
+          session = openSessionFor(api, action.getCollectionId());
           // Store before running setup so a setup failure still leaves the session in the map
           // for the rollback/close paths below.
-          sessionsByProvider.put(provider.getId(), session);
+          sessionsByProvider.put(providerId, session);
           warnings.addAll(session.execute(setup));
+          if (collectErrors && !session.supportsSavepoints()) {
+            LOGGER.warn(
+                "collectErrors is enabled but the feature provider session does not support"
+                    + " savepoints — stopping at the first error for this transaction");
+            collectErrors = false;
+          }
         }
-        results.add(
+        boolean savepointActive = false;
+        if (collectErrors) {
+          session.savepoint();
+          savepointActive = true;
+        }
+        result =
             runAction(
                 action,
-                provider,
                 session,
                 api,
                 ctx,
@@ -251,26 +288,40 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
                 ogcMutationDatetime,
                 validate,
                 false,
-                transaction.isWfs()));
-        ActionResult lastResult = last(results);
-        if (lastResult.getStatus() == ActionStatus.FAILED) {
-          firstError =
-              new RuntimeException(
-                  lastResult.getError().orElse("action " + actionLabel(action) + " failed"));
-        } else if (lastResult.getStatus() == ActionStatus.SUCCESS) {
-          touchedIdsByCollection
-              .computeIfAbsent(lastResult.getCollectionId(), k -> new HashSet<>())
-              .addAll(lastResult.getFeatureIds());
+                transaction.isWfs());
+        result = withActionWarnings(result, session);
+        if (result.getStatus() == ActionStatus.FAILED) {
+          anyFailed = true;
+          if (savepointActive) {
+            // undo just this action's writes; the transaction stays usable for the rest
+            session.rollbackToSavepoint();
+          }
+        } else {
+          if (savepointActive) {
+            session.releaseSavepoint();
+          }
+          if (result.getStatus() == ActionStatus.SUCCESS) {
+            touchedIdsByCollection
+                .computeIfAbsent(result.getCollectionId(), k -> new HashSet<>())
+                .addAll(result.getFeatureIds());
+          }
         }
       } catch (RuntimeException e) {
+        // session acquisition, a setup hook, or savepoint handling failed — the transaction is
+        // no longer usable
         recoverHookWarnings(e, warnings);
-        results.add(failed(action, e));
-        firstError = e;
+        if (result == null) {
+          result = failed(canonicalCollectionId(api, action.getCollectionId()), action, e);
+        }
+        anyFailed = true;
+        fatalError = e;
       }
+      results.add(result);
     }
 
     boolean commitSucceeded = false;
-    if (firstError == null) {
+    Optional<String> transactionError = Optional.empty();
+    if (!anyFailed) {
       try {
         // Pre-commit hooks run on the still-open transaction; a raised error aborts the
         // whole transaction, a warning lets it commit and is surfaced in the response.
@@ -280,8 +331,8 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
         sessionsByProvider.values().forEach(Session::commit);
         commitSucceeded = true;
       } catch (RuntimeException e) {
-        // pre-commit or commit failed — flip every recorded SUCCESS to FAILED with the error,
-        // rollback whatever can still be rolled back
+        // pre-commit or commit failed — a transaction-level error not attributable to a single
+        // action; rollback whatever can still be rolled back
         recoverHookWarnings(e, warnings);
         if (e instanceof FeatureMutationHookException) {
           // expected, configuration-driven rollback (a hook check fired) — reported to the
@@ -291,10 +342,12 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
           LOGGER.warn("Atomic transaction commit failed", e);
         }
         rollbackQuietly(sessionsByProvider.values());
-        results = flipSuccessesToFailed(results, e);
+        transactionError = Optional.of("atomic commit failed: " + errorMessage(e));
+        results = flipSuccessesToRolledBack(results);
       }
     } else {
       rollbackQuietly(sessionsByProvider.values());
+      results = flipSuccessesToRolledBack(results);
     }
     closeQuietly(sessionsByProvider.values());
 
@@ -306,6 +359,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
         .semantic(TxSemantic.ATOMIC)
         .actionResults(results)
         .warnings(warnings)
+        .transactionError(transactionError)
         .build();
   }
 
@@ -320,8 +374,9 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
       Optional<Instant> ogcMutationDatetime) {
     // handling=strict turns on per-payload schema validation before any write.
     boolean validate = handling == HeaderPrefer.Handling.STRICT;
-    List<String> setup = hookStatements(api, handling, false);
-    List<String> preCommit = hookStatements(api, handling, true);
+    TransactionsConfiguration cfg = transactionsConfig(api);
+    List<String> setup = hookStatements(cfg, handling, false);
+    List<String> preCommit = hookStatements(cfg, handling, true);
     List<String> warnings = new ArrayList<>();
     List<ActionResult> results = new ArrayList<>();
     // Reused across actions in a batch even though each action commits independently — keeps the
@@ -333,8 +388,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
       TxAction action = actions.next();
       Session session = null;
       try {
-        FeatureProvider provider = resolveProvider(api, action.getCollectionId());
-        session = openSession(provider, action.getCollectionId());
+        session = openSessionFor(api, action.getCollectionId());
         warnings.addAll(session.execute(setup));
         // Batch semantics commit between actions, so each action sees a fresh committed
         // snapshot — no need to track touched ids across actions.
@@ -343,7 +397,6 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
         ActionResult r =
             runAction(
                 action,
-                provider,
                 session,
                 api,
                 ctx,
@@ -355,6 +408,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
                 validate,
                 true,
                 transaction.isWfs());
+        r = withActionWarnings(r, session);
         if (r.getStatus() == ActionStatus.SUCCESS) {
           // Pre-commit hooks run per action under batch semantics; a raised error fails just
           // this action (caught below), a warning lets it commit and is surfaced.
@@ -376,7 +430,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
             // already failing, swallow
           }
         }
-        results.add(failed(action, e));
+        results.add(failed(canonicalCollectionId(api, action.getCollectionId()), action, e));
       } finally {
         if (session != null) {
           try {
@@ -399,9 +453,10 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
 
   // --- action dispatch ------------------------------------------------------
 
-  private ActionResult runAction(
+  // Package-private so specs can script per-action outcomes via an anonymous subclass without
+  // stubbing the OgcApi / FeatureProvider graph (see transactionsConfig above).
+  ActionResult runAction(
       TxAction action,
-      FeatureProvider provider,
       Session session,
       OgcApi api,
       ApiRequestContext ctx,
@@ -459,7 +514,6 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
         case UPDATE ->
             runUpdate(
                 (TxUpdate) action,
-                provider,
                 session,
                 api,
                 ctx,
@@ -479,7 +533,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
         default -> throw new IllegalArgumentException("Unknown action type: " + action.getType());
       };
     } catch (RuntimeException e) {
-      return failed(action, e);
+      return failed(canonicalCollectionId(api, action.getCollectionId()), action, e);
     }
   }
 
@@ -535,6 +589,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
           && canonicalIdForItem.isPresent()
           && touched.contains(canonicalIdForItem.get())) {
         return failed(
+            canonicalCollectionId,
             action,
             chainRejectError(canonicalCollectionId, canonicalIdForItem.get(), action),
             List.of(canonicalIdForItem.get()));
@@ -565,7 +620,11 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
         MutationResult precheck =
             session.assertNoConflictingVersion(featureType, canonicalIdForItem.get());
         if (precheck.getError().isPresent()) {
-          return failed(action, precheck.getError().get(), List.of(canonicalIdForItem.get()));
+          return failed(
+              canonicalCollectionId,
+              action,
+              precheck.getError().get(),
+              List.of(canonicalIdForItem.get()));
         }
       }
       try (InputStream payload = item.payload()) {
@@ -755,7 +814,12 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
         candidatePayloads.add(payloadString(it));
       }
     }
-    return failed(action, error, candidateIds, candidatePayloads);
+    return failed(
+        canonicalCollectionId(apiData, action.getCollectionId()),
+        action,
+        error,
+        candidateIds,
+        candidatePayloads);
   }
 
   private ActionResult runReplace(
@@ -783,7 +847,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
     if (targetIds.isEmpty()) {
       throw new IllegalArgumentException(
           "Replace action filter matched no feature ids for collection '"
-              + action.getCollectionId()
+              + canonicalCollectionId
               + "'.");
     }
     if (targetIds.size() > 1) {
@@ -791,7 +855,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
           "Replace action must target exactly one feature id; got "
               + targetIds.size()
               + " for collection '"
-              + action.getCollectionId()
+              + canonicalCollectionId
               + "'.");
     }
     String rawId = targetIds.get(0);
@@ -806,7 +870,10 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
             strategy, apiData, action, List.of(id), touchedIdsByCollection, canonicalCollectionId);
     if (chainConflict != null) {
       return failed(
-          action, chainRejectError(canonicalCollectionId, chainConflict, action), List.of(id));
+          canonicalCollectionId,
+          action,
+          chainRejectError(canonicalCollectionId, chainConflict, action),
+          List.of(id));
     }
 
     MutationResult mr;
@@ -858,7 +925,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
                 "Precondition failed: feature id '"
                     + id
                     + "' in collection '"
-                    + action.getCollectionId()
+                    + canonicalCollectionId
                     + "' has no open version with PRIMARY_INTERVAL_START = "
                     + composite.expectedStart().get()
                     + " (the composite rid suffix is stale or the open version has been"
@@ -868,7 +935,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
               "No open version of feature id '"
                   + id
                   + "' in collection '"
-                  + action.getCollectionId()
+                  + canonicalCollectionId
                   + "' was available for retirement (already retired or unknown).");
         }
         Map<SchemaBase.Role, Object> roleOverrides =
@@ -891,7 +958,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
         rejectIfError(mr);
       }
     } catch (RuntimeException e) {
-      return failed(action, e, List.of(id));
+      return failed(canonicalCollectionId, action, e, List.of(id));
     }
 
     return new ImmutableActionResult.Builder()
@@ -907,7 +974,6 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
 
   private ActionResult runUpdate(
       TxUpdate action,
-      FeatureProvider provider,
       Session session,
       OgcApi api,
       ApiRequestContext ctx,
@@ -931,7 +997,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
     if (targetIds.isEmpty()) {
       throw new IllegalArgumentException(
           "Update action filter matched no feature ids for collection '"
-              + action.getCollectionId()
+              + canonicalCollectionId
               + "'.");
     }
 
@@ -940,7 +1006,10 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
             strategy, apiData, action, targetIds, touchedIdsByCollection, canonicalCollectionId);
     if (chainConflict != null) {
       return failed(
-          action, chainRejectError(canonicalCollectionId, chainConflict, action), targetIds);
+          canonicalCollectionId,
+          action,
+          chainRejectError(canonicalCollectionId, chainConflict, action),
+          targetIds);
     }
 
     // Every Update is a native SQL UPDATE issued on the session's own connection, so
@@ -957,7 +1026,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
       // Action-level failure (bad payload, non-whitelisted property, unknown path, etc.) —
       // attribute it to every target id so the log line and the result both name the
       // features the client tried to update.
-      return failed(action, e, targetIds);
+      return failed(canonicalCollectionId, action, e, targetIds);
     }
 
     MutationStrategy.UpdateMode mode;
@@ -965,7 +1034,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
       FeatureSchema schema = resolveFeatureSchema(apiData, canonicalCollectionId);
       mode = strategy.chooseUpdateMode(apiData, schema, action, updates, mutationTimestamp);
     } catch (RuntimeException e) {
-      return failed(action, e, targetIds);
+      return failed(canonicalCollectionId, action, e, targetIds);
     }
 
     List<String> updatedIds = new ArrayList<>();
@@ -993,12 +1062,13 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
                   || mode == MutationStrategy.UpdateMode.CLONE_AND_PATCH;
           if (retireOrClone && composite.expectedStart().isPresent()) {
             return failed(
+                canonicalCollectionId,
                 action,
                 new IllegalArgumentException(
                     "Precondition failed: feature id '"
                         + id
                         + "' in collection '"
-                        + action.getCollectionId()
+                        + canonicalCollectionId
                         + "' has no open version with PRIMARY_INTERVAL_START = "
                         + composite.expectedStart().get()
                         + " (the composite rid suffix is stale or the open version has been"
@@ -1010,7 +1080,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
           updatedIds.addAll(mr.getIds());
         }
       } catch (RuntimeException e) {
-        return failed(action, e, List.of(id));
+        return failed(canonicalCollectionId, action, e, List.of(id));
       }
     }
 
@@ -1232,7 +1302,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
     if (targetIds.isEmpty()) {
       throw new IllegalArgumentException(
           "Delete action filter matched no feature ids for collection '"
-              + action.getCollectionId()
+              + canonicalCollectionId
               + "'.");
     }
 
@@ -1241,7 +1311,10 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
             strategy, apiData, action, targetIds, touchedIdsByCollection, canonicalCollectionId);
     if (chainConflict != null) {
       return failed(
-          action, chainRejectError(canonicalCollectionId, chainConflict, action), targetIds);
+          canonicalCollectionId,
+          action,
+          chainRejectError(canonicalCollectionId, chainConflict, action),
+          targetIds);
     }
 
     String featureType = resolveFeatureType(api.getData(), action.getCollectionId());
@@ -1271,7 +1344,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
                   "Precondition failed: feature id '"
                       + id
                       + "' in collection '"
-                      + action.getCollectionId()
+                      + canonicalCollectionId
                       + "' has no open version with PRIMARY_INTERVAL_START = "
                       + composite.expectedStart().get()
                       + " (the composite rid suffix is stale or the open version has been"
@@ -1281,7 +1354,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
                 "No open version of feature id '"
                     + id
                     + "' in collection '"
-                    + action.getCollectionId()
+                    + canonicalCollectionId
                     + "' was available for retirement (already retired or unknown).");
           }
           deleted.addAll(mr.getIds());
@@ -1295,7 +1368,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
           }
         }
       } catch (RuntimeException e) {
-        return failed(action, e, List.of(id));
+        return failed(canonicalCollectionId, action, e, List.of(id));
       }
     }
 
@@ -1772,22 +1845,22 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
             });
   }
 
-  private static ActionResult skipped(TxAction action) {
+  private static ActionResult skipped(String collectionId, TxAction action) {
     return new ImmutableActionResult.Builder()
         .type(action.getType())
-        .collectionId(action.getCollectionId())
+        .collectionId(collectionId)
         .actionId(action.getActionId())
         .status(ActionStatus.SKIPPED)
         .build();
   }
 
-  private static ActionResult failed(TxAction action, Throwable error) {
-    return failed(action, error, List.of(), List.of());
+  private static ActionResult failed(String collectionId, TxAction action, Throwable error) {
+    return failed(collectionId, action, error, List.of(), List.of());
   }
 
   private static ActionResult failed(
-      TxAction action, Throwable error, List<String> failedFeatureIds) {
-    return failed(action, error, failedFeatureIds, List.of());
+      String collectionId, TxAction action, Throwable error, List<String> failedFeatureIds) {
+    return failed(collectionId, action, error, failedFeatureIds, List.of());
   }
 
   // Build a FAILED ActionResult and log the failure. User-input errors
@@ -1799,6 +1872,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
   // request. In the log line we truncate the payload to keep entries readable; the full
   // payload is preserved in the ActionResult.
   private static ActionResult failed(
+      String collectionId,
       TxAction action,
       Throwable error,
       List<String> failedFeatureIds,
@@ -1812,7 +1886,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
     }
     return new ImmutableActionResult.Builder()
         .type(action.getType())
-        .collectionId(action.getCollectionId())
+        .collectionId(collectionId)
         .actionId(action.getActionId())
         .status(ActionStatus.FAILED)
         .error(errorMessage(error))
@@ -1866,26 +1940,35 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
     return error instanceof IllegalArgumentException;
   }
 
-  private static ActionResult last(List<ActionResult> results) {
-    return results.get(results.size() - 1);
-  }
-
   private static String actionLabel(TxAction action) {
     return action.getActionId().orElse(action.getType() + "@" + action.getCollectionId());
   }
 
-  private static List<ActionResult> flipSuccessesToFailed(
-      List<ActionResult> results, Throwable cause) {
+  /**
+   * Attaches the non-fatal SQL warnings the session collected while this action ran (e.g.
+   * PostgreSQL {@code RAISE WARNING} / {@code RAISE NOTICE} from triggers). Draining per action
+   * attributes each warning to the action that caused it.
+   */
+  private static ActionResult withActionWarnings(ActionResult result, Session session) {
+    List<String> actionWarnings = session.drainWarnings();
+    if (actionWarnings.isEmpty()) {
+      return result;
+    }
+    return new ImmutableActionResult.Builder().from(result).warnings(actionWarnings).build();
+  }
+
+  /**
+   * The atomic transaction failed after some actions had already succeeded — their writes are gone,
+   * so their results must not read as successes in the response.
+   */
+  private static List<ActionResult> flipSuccessesToRolledBack(List<ActionResult> results) {
     List<ActionResult> out = new ArrayList<>(results.size());
     for (ActionResult r : results) {
       if (r.getStatus() == ActionStatus.SUCCESS) {
         out.add(
             new ImmutableActionResult.Builder()
                 .from(r)
-                .status(ActionStatus.FAILED)
-                .error(
-                    "atomic commit failed: "
-                        + (cause.getMessage() == null ? cause.toString() : cause.getMessage()))
+                .status(ActionStatus.ROLLED_BACK)
                 .featureIds(List.of())
                 .build());
       } else {

--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/ActionResult.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/ActionResult.java
@@ -41,6 +41,17 @@ public interface ActionResult {
   Optional<String> getError();
 
   /**
+   * Non-fatal warnings the data source emitted while executing this action (e.g. PostgreSQL {@code
+   * RAISE WARNING} / {@code RAISE NOTICE} from triggers or functions invoked by the action's
+   * statements). Present on any outcome — a failed action keeps the warnings emitted before its
+   * error.
+   */
+  @Value.Default
+  default List<String> getWarnings() {
+    return List.of();
+  }
+
+  /**
    * Source-side identifiers (e.g. gml:id, GeoJSON id) of the features that may have caused a FAILED
    * outcome. For inserts that fail at batch commit time, this is the full set of feature ids in the
    * failing batch — the broken one is among them but cannot be narrowed further from a batch error.

--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/ActionStatus.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/ActionStatus.java
@@ -19,5 +19,11 @@ public enum ActionStatus {
   SKIPPED,
 
   /** Action ran or was rejected before any change was made and produced an error. */
-  FAILED
+  FAILED,
+
+  /**
+   * Atomic-only: action ran successfully, but its changes were undone because the transaction as a
+   * whole failed (a sibling action failed, or the commit was aborted).
+   */
+  ROLLED_BACK
 }

--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/ExecutionResult.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/ExecutionResult.java
@@ -8,6 +8,7 @@
 package de.ii.ogcapi.transactions.domain;
 
 import java.util.List;
+import java.util.Optional;
 import org.immutables.value.Value;
 
 /** Result of executing a {@link Transaction}. */
@@ -29,10 +30,18 @@ public interface ExecutionResult {
    */
   List<String> getWarnings();
 
+  /**
+   * Transaction-level failure that is not attributable to a single action — a failed pre-commit
+   * hook or a failed commit. Every action that had succeeded is {@link ActionStatus#ROLLED_BACK} in
+   * that case.
+   */
+  Optional<String> getTransactionError();
+
   /** Whether the transaction as a whole succeeded (no FAILED actions in atomic; any in batch). */
   @Value.Derived
   default boolean isSuccess() {
-    return getActionResults().stream().noneMatch(r -> r.getStatus() == ActionStatus.FAILED);
+    return getTransactionError().isEmpty()
+        && getActionResults().stream().noneMatch(r -> r.getStatus() == ActionStatus.FAILED);
   }
 
   @Value.Derived
@@ -58,6 +67,18 @@ public interface ExecutionResult {
   @Value.Derived
   default long getFailedCount() {
     return getActionResults().stream().filter(r -> r.getStatus() == ActionStatus.FAILED).count();
+  }
+
+  @Value.Derived
+  default long getRolledBackCount() {
+    return getActionResults().stream()
+        .filter(r -> r.getStatus() == ActionStatus.ROLLED_BACK)
+        .count();
+  }
+
+  @Value.Derived
+  default long getSkippedCount() {
+    return getActionResults().stream().filter(r -> r.getStatus() == ActionStatus.SKIPPED).count();
   }
 
   private long countFeatures(TxActionType type) {

--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/TransactionsConfiguration.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/TransactionsConfiguration.java
@@ -25,6 +25,7 @@ import org.immutables.value.Value;
  *   batch: true
  *   wfsTransaction: false
  *   defaultSemantic: ATOMIC
+ *   collectErrors: true
  * ```
  *
  * Per-collection partial-update whitelist (allows `wfs:Update` / JSON-transaction `update`
@@ -137,6 +138,35 @@ public interface TransactionsConfiguration extends ExtensionConfiguration {
    */
   @Nullable
   Integer getMaxActionsPerRequest();
+
+  /**
+   * @langEn Only relevant for atomic semantics. When enabled, a failing action does not stop the
+   *     processing of the transaction: the remaining actions are still executed, every error is
+   *     collected, and the response reports all of them, while all changes are still rolled back.
+   *     This lets clients fix every error in a large transaction in one pass instead of one error
+   *     per attempt. Later actions see the changes of earlier successful actions, but not those of
+   *     failed actions — an action that depends on a failed action therefore typically reports a
+   *     follow-on error. Each action adds a small database overhead (a savepoint), which can be
+   *     noticeable in very large transactions. Requires a SQL feature provider; otherwise the
+   *     option is ignored. When disabled, processing stops at the first error, the remaining
+   *     actions are skipped, and only the first error is reported.
+   * @langDe Nur für atomare Semantik relevant. Wenn aktiviert, beendet eine fehlschlagende Aktion
+   *     die Verarbeitung der Transaktion nicht: Die verbleibenden Aktionen werden trotzdem
+   *     ausgeführt, alle Fehler werden gesammelt und in der Antwort gemeldet, während alle
+   *     Änderungen dennoch zurückgerollt werden. Clients können so alle Fehler einer großen
+   *     Transaktion in einem Durchgang beheben statt einen Fehler pro Versuch. Spätere Aktionen
+   *     sehen die Änderungen früherer erfolgreicher Aktionen, nicht aber die fehlgeschlagener
+   *     Aktionen — eine Aktion, die von einer fehlgeschlagenen Aktion abhängt, meldet daher in der
+   *     Regel einen Folgefehler. Jede Aktion verursacht einen kleinen Mehraufwand in der Datenbank
+   *     (einen Savepoint), der bei sehr großen Transaktionen spürbar sein kann. Erfordert einen
+   *     SQL-Feature-Provider; andernfalls wird die Option ignoriert. Wenn deaktiviert, stoppt die
+   *     Verarbeitung beim ersten Fehler, die verbleibenden Aktionen werden übersprungen und nur der
+   *     erste Fehler wird gemeldet.
+   * @default false
+   * @since v4.8
+   */
+  @Nullable
+  Boolean getCollectErrors();
 
   /**
    * @langEn Whitelist of feature properties that may be the target of a partial update (the

--- a/ogcapi-draft/ogcapi-transactions/src/test/groovy/de/ii/ogcapi/transactions/app/CommandHandlerTransactionsSpec.groovy
+++ b/ogcapi-draft/ogcapi-transactions/src/test/groovy/de/ii/ogcapi/transactions/app/CommandHandlerTransactionsSpec.groovy
@@ -10,8 +10,12 @@ package de.ii.ogcapi.transactions.app
 import de.ii.ogcapi.foundation.domain.ApiRequestContext
 import de.ii.ogcapi.foundation.domain.HeaderPrefer
 import de.ii.ogcapi.foundation.domain.OgcApi
+import de.ii.ogcapi.transactions.domain.ActionStatus
 import de.ii.ogcapi.transactions.domain.ExecutionResult
+import de.ii.ogcapi.transactions.domain.ImmutableActionResult
 import de.ii.ogcapi.transactions.domain.ImmutableExecutionResult
+import de.ii.ogcapi.transactions.domain.TxActionType
+import groovy.json.JsonSlurper
 import de.ii.ogcapi.transactions.domain.ImmutableTransactionsConfiguration
 import de.ii.ogcapi.transactions.domain.ImmutableTxDelete
 import de.ii.ogcapi.transactions.domain.Transaction
@@ -85,6 +89,112 @@ class CommandHandlerTransactionsSpec extends Specification {
         then:
         response.status == 200
         executor.seen == 1
+    }
+
+    def 'a failed atomic transaction reports every error and hides rolled-back successes'() {
+        given:
+        RecordingParser parser = new RecordingParser(actions: [])
+        FixedResultExecutor executor = new FixedResultExecutor(result: new ImmutableExecutionResult.Builder()
+                .semantic(TxSemantic.ATOMIC)
+                .actionResults([
+                        actionResult('a1', ActionStatus.FAILED, 'first error'),
+                        actionResult('a2', ActionStatus.FAILED, 'second error'),
+                        actionResult('a3', ActionStatus.ROLLED_BACK, null),
+                        actionResult('a4', ActionStatus.SKIPPED, null),
+                ])
+                .build())
+        CommandHandlerTransactionsImpl handler = new CommandHandlerTransactionsImpl(executor, volatileRegistry)
+
+        when:
+        def response = handler.processTransaction(
+                queryInput(parser, '{"transaction":[]}', config(0), HeaderPrefer.Handling.LENIENT),
+                requestContext())
+        def json = (Map) new JsonSlurper().parseText((String) response.entity)
+
+        then:
+        response.status == 422
+
+        and: 'one exception per failed action, in request order'
+        List exceptions = (List) json.get('exceptions')
+        exceptions.size() == 2
+        ((Map) exceptions[0]).get('detail') == 'first error'
+        ((Map) exceptions[1]).get('detail') == 'second error'
+
+        and: 'rolled-back and skipped actions are counted but contribute no successes'
+        Map summary = (Map) json.get('summary')
+        summary.get('totalDeleted') == 0
+        summary.get('totalFailed') == 2
+        summary.get('totalRolledBack') == 1
+        summary.get('totalSkipped') == 1
+        ((List) json.get('deleteResults')).isEmpty()
+    }
+
+    def 'a transaction-level error (failed commit or pre-commit hook) is rendered as its own exception'() {
+        given:
+        RecordingParser parser = new RecordingParser(actions: [])
+        FixedResultExecutor executor = new FixedResultExecutor(result: new ImmutableExecutionResult.Builder()
+                .semantic(TxSemantic.ATOMIC)
+                .actionResults([actionResult('a1', ActionStatus.ROLLED_BACK, null)])
+                .transactionError('atomic commit failed: deferred constraint')
+                .build())
+        CommandHandlerTransactionsImpl handler = new CommandHandlerTransactionsImpl(executor, volatileRegistry)
+
+        when:
+        def response = handler.processTransaction(
+                queryInput(parser, '{"transaction":[]}', config(0), HeaderPrefer.Handling.LENIENT),
+                requestContext())
+        def json = (Map) new JsonSlurper().parseText((String) response.entity)
+
+        then:
+        response.status == 422
+        List exceptions = (List) json.get('exceptions')
+        exceptions.size() == 1
+        ((Map) exceptions[0]).get('title') == 'Transaction failed'
+        ((Map) exceptions[0]).get('detail') == 'atomic commit failed: deferred constraint'
+        ((Map) json.get('summary')).get('totalRolledBack') == 1
+    }
+
+    def 'per-action warnings are rendered with the action label, after the hook warnings'() {
+        given:
+        RecordingParser parser = new RecordingParser(actions: [])
+        FixedResultExecutor executor = new FixedResultExecutor(result: new ImmutableExecutionResult.Builder()
+                .semantic(TxSemantic.ATOMIC)
+                .actionResults([new ImmutableActionResult.Builder()
+                                        .type(TxActionType.DELETE)
+                                        .collectionId('c')
+                                        .actionId('a1')
+                                        .status(ActionStatus.SUCCESS)
+                                        .warnings(['trigger touched a protected row'])
+                                        .build()])
+                .warnings(['pre-commit check: 2 orphaned rows'])
+                .build())
+        CommandHandlerTransactionsImpl handler = new CommandHandlerTransactionsImpl(executor, volatileRegistry)
+
+        when:
+        def response = handler.processTransaction(
+                queryInput(parser, '{"transaction":[]}', config(0), HeaderPrefer.Handling.LENIENT),
+                requestContext())
+        def json = (Map) new JsonSlurper().parseText((String) response.entity)
+
+        then:
+        response.status == 200
+        ((List) json.get('warnings')) == [
+                'pre-commit check: 2 orphaned rows',
+                'action a1: trigger touched a protected row',
+        ]
+    }
+
+    private static de.ii.ogcapi.transactions.domain.ActionResult actionResult(
+            String actionId, ActionStatus status, String error) {
+        def builder = new ImmutableActionResult.Builder()
+                .type(TxActionType.DELETE)
+                .collectionId('c')
+                .actionId(actionId)
+                .status(status)
+        if (error != null) {
+            builder.error(error)
+        }
+        return builder.build()
     }
 
     private static CommandHandlerTransactions.QueryInputTransaction queryInput(
@@ -162,6 +272,22 @@ class CommandHandlerTransactionsSpec extends Specification {
         @Override
         void close() {
             closed = true
+        }
+    }
+
+    private static class FixedResultExecutor extends CountingExecutor {
+        ExecutionResult result
+
+        @Override
+        ExecutionResult execute(
+                Transaction transaction,
+                OgcApi api,
+                ApiRequestContext requestContext,
+                EpsgCrs requestCrs,
+                HeaderPrefer.Handling handling,
+                Optional<Instant> ogcMutationDatetime) {
+            super.execute(transaction, api, requestContext, requestCrs, handling, ogcMutationDatetime)
+            return result
         }
     }
 

--- a/ogcapi-draft/ogcapi-transactions/src/test/groovy/de/ii/ogcapi/transactions/app/TransactionExecutorAtomicSpec.groovy
+++ b/ogcapi-draft/ogcapi-transactions/src/test/groovy/de/ii/ogcapi/transactions/app/TransactionExecutorAtomicSpec.groovy
@@ -1,0 +1,392 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.transactions.app
+
+import de.ii.ogcapi.features.core.domain.FeaturesCoreQueriesHandler
+import de.ii.ogcapi.foundation.domain.ApiRequestContext
+import de.ii.ogcapi.foundation.domain.HeaderPrefer
+import de.ii.ogcapi.foundation.domain.OgcApi
+import de.ii.ogcapi.transactions.domain.ActionResult
+import de.ii.ogcapi.transactions.domain.ActionStatus
+import de.ii.ogcapi.transactions.domain.ExecutionResult
+import de.ii.ogcapi.transactions.domain.ImmutableActionResult
+import de.ii.ogcapi.transactions.domain.ImmutableTransactionsConfiguration
+import de.ii.ogcapi.transactions.domain.ImmutableTxDelete
+import de.ii.ogcapi.transactions.domain.MutationStrategy
+import de.ii.ogcapi.transactions.domain.Transaction
+import de.ii.ogcapi.transactions.domain.TransactionsConfiguration
+import de.ii.ogcapi.transactions.domain.TxAction
+import de.ii.ogcapi.transactions.domain.TxActionType
+import de.ii.ogcapi.transactions.domain.TxSemantic
+import de.ii.xtraplatform.base.domain.resiliency.VolatileRegistry
+import de.ii.xtraplatform.crs.domain.EpsgCrs
+import de.ii.xtraplatform.crs.domain.OgcCrs
+import de.ii.xtraplatform.features.domain.FeatureTokenSource
+import de.ii.xtraplatform.features.domain.FeatureTransactions
+import spock.lang.Specification
+
+import java.time.Instant
+
+/**
+ * Unit-level guard for the atomic execution loop: stop-at-first-error vs. collectErrors
+ * semantics, the per-action savepoint lifecycle, the SUCCESS-to-ROLLED_BACK flip on failed
+ * transactions, and the fatal-error path that skips the remaining actions.
+ *
+ * <p>Per-action outcomes are scripted through the package-private {@code runAction} seam and
+ * sessions are recording fakes, following the pattern documented in
+ * {@link TransactionExecutorChangesSpec} (the full OgcApi / FeatureProvider graph cannot be
+ * stubbed on this test classpath).
+ */
+class TransactionExecutorAtomicSpec extends Specification {
+
+    def 'stop-at-first-error: remaining actions are skipped, successes are rolled back, one error is reported'() {
+        given:
+        RecordingSession session = new RecordingSession()
+        TransactionExecutorImpl executor = newExecutor(config(false), session, [
+                a1: { success('a1', ['f1']) },
+                a2: { failure('a2', 'boom') },
+                a3: { success('a3', ['f3']) },
+        ])
+
+        when:
+        ExecutionResult result = executor.execute(
+                transaction('a1', 'a2', 'a3'), null, null, OgcCrs.CRS84,
+                HeaderPrefer.Handling.LENIENT, Optional.empty())
+
+        then:
+        statuses(result) == [ActionStatus.ROLLED_BACK, ActionStatus.FAILED, ActionStatus.SKIPPED]
+        !result.isSuccess()
+        result.transactionError.isEmpty()
+
+        and: 'no savepoints are used and the session is rolled back, not committed'
+        session.calls.findAll { it.startsWith('savepoint') }.isEmpty()
+        session.calls.contains('rollback')
+        !session.calls.contains('commit')
+    }
+
+    def 'collectErrors: every action runs, all errors are reported, everything is still rolled back'() {
+        given:
+        RecordingSession session = new RecordingSession()
+        TransactionExecutorImpl executor = newExecutor(config(true), session, [
+                a1: { success('a1', ['f1']) },
+                a2: { failure('a2', 'first error') },
+                a3: { failure('a3', 'second error') },
+                a4: { success('a4', ['f4']) },
+        ])
+
+        when:
+        ExecutionResult result = executor.execute(
+                transaction('a1', 'a2', 'a3', 'a4'), null, null, OgcCrs.CRS84,
+                HeaderPrefer.Handling.LENIENT, Optional.empty())
+
+        then: 'both errors surface, the successes flip to ROLLED_BACK'
+        statuses(result) == [ActionStatus.ROLLED_BACK, ActionStatus.FAILED, ActionStatus.FAILED, ActionStatus.ROLLED_BACK]
+        result.actionResults[1].error.get() == 'first error'
+        result.actionResults[2].error.get() == 'second error'
+        !result.isSuccess()
+
+        and: 'each action ran inside a savepoint: released on success, rolled back on failure'
+        session.calls == ['execute',
+                          'savepoint', 'release',
+                          'savepoint', 'rollbackTo',
+                          'savepoint', 'rollbackTo',
+                          'savepoint', 'release',
+                          'rollback', 'close']
+    }
+
+    def 'collectErrors with an all-success transaction commits and keeps SUCCESS statuses'() {
+        given:
+        RecordingSession session = new RecordingSession()
+        TransactionExecutorImpl executor = newExecutor(config(true), session, [
+                a1: { success('a1', ['f1']) },
+                a2: { success('a2', ['f2']) },
+        ])
+
+        when:
+        ExecutionResult result = executor.execute(
+                transaction('a1', 'a2'), null, null, OgcCrs.CRS84,
+                HeaderPrefer.Handling.LENIENT, Optional.empty())
+
+        then:
+        statuses(result) == [ActionStatus.SUCCESS, ActionStatus.SUCCESS]
+        result.isSuccess()
+        session.calls == ['execute',
+                          'savepoint', 'release',
+                          'savepoint', 'release',
+                          'execute', 'commit', 'close']
+    }
+
+    def 'a failed rollback-to-savepoint is fatal: the remaining actions are skipped'() {
+        given:
+        RecordingSession session = new RecordingSession(
+                throwOnRollbackToSavepoint: new IllegalStateException('connection lost'))
+        TransactionExecutorImpl executor = newExecutor(config(true), session, [
+                a1: { failure('a1', 'boom') },
+                a2: { success('a2', ['f2']) },
+        ])
+
+        when:
+        ExecutionResult result = executor.execute(
+                transaction('a1', 'a2'), null, null, OgcCrs.CRS84,
+                HeaderPrefer.Handling.LENIENT, Optional.empty())
+
+        then: 'the failing action keeps its own error, the rest is skipped'
+        statuses(result) == [ActionStatus.FAILED, ActionStatus.SKIPPED]
+        result.actionResults[0].error.get() == 'boom'
+        !result.isSuccess()
+        !session.calls.contains('commit')
+    }
+
+    def 'collectErrors falls back to stop-at-first-error when the session does not support savepoints'() {
+        given:
+        RecordingSession session = new RecordingSession(savepoints: false)
+        TransactionExecutorImpl executor = newExecutor(config(true), session, [
+                a1: { failure('a1', 'boom') },
+                a2: { success('a2', ['f2']) },
+        ])
+
+        when:
+        ExecutionResult result = executor.execute(
+                transaction('a1', 'a2'), null, null, OgcCrs.CRS84,
+                HeaderPrefer.Handling.LENIENT, Optional.empty())
+
+        then:
+        statuses(result) == [ActionStatus.FAILED, ActionStatus.SKIPPED]
+        session.calls.findAll { it.startsWith('savepoint') }.isEmpty()
+    }
+
+    def 'per-action SQL warnings are drained from the session and attached to the action result'() {
+        given:
+        RecordingSession session = new RecordingSession()
+        TransactionExecutorImpl executor = newExecutor(config(false), session, [
+                a1: { session.nextWarnings = ['trigger touched a protected row']; success('a1', ['f1']) },
+                a2: { success('a2', ['f2']) },
+        ])
+
+        when:
+        ExecutionResult result = executor.execute(
+                transaction('a1', 'a2'), null, null, OgcCrs.CRS84,
+                HeaderPrefer.Handling.LENIENT, Optional.empty())
+
+        then:
+        result.actionResults[0].warnings == ['trigger touched a protected row']
+        result.actionResults[1].warnings.isEmpty()
+    }
+
+    def 'a failed commit rolls back all successes and reports a transaction-level error'() {
+        given:
+        RecordingSession session = new RecordingSession(throwOnCommit: new IllegalStateException('deferred constraint'))
+        TransactionExecutorImpl executor = newExecutor(config(false), session, [
+                a1: { success('a1', ['f1']) },
+        ])
+
+        when:
+        ExecutionResult result = executor.execute(
+                transaction('a1'), null, null, OgcCrs.CRS84,
+                HeaderPrefer.Handling.LENIENT, Optional.empty())
+
+        then:
+        statuses(result) == [ActionStatus.ROLLED_BACK]
+        !result.isSuccess()
+        result.transactionError.get().contains('deferred constraint')
+        session.calls.contains('rollback')
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // helpers
+    // ---------------------------------------------------------------------------------------------
+
+    private static List<ActionStatus> statuses(ExecutionResult result) {
+        return result.actionResults.collect { it.status }
+    }
+
+    private static TransactionsConfiguration config(boolean collectErrors) {
+        return new ImmutableTransactionsConfiguration.Builder()
+                .atomic(true)
+                .collectErrors(collectErrors)
+                .build()
+    }
+
+    private static ActionResult success(String actionId, List<String> ids) {
+        return new ImmutableActionResult.Builder()
+                .type(TxActionType.DELETE)
+                .collectionId('c')
+                .actionId(actionId)
+                .status(ActionStatus.SUCCESS)
+                .featureIds(ids)
+                .build()
+    }
+
+    private static ActionResult failure(String actionId, String error) {
+        return new ImmutableActionResult.Builder()
+                .type(TxActionType.DELETE)
+                .collectionId('c')
+                .actionId(actionId)
+                .status(ActionStatus.FAILED)
+                .error(error)
+                .build()
+    }
+
+    private static Transaction transaction(String... actionIds) {
+        List<TxAction> actions = actionIds.collect {
+            new ImmutableTxDelete.Builder().collectionId('c').actionId(it).addTargetIds('f').build() as TxAction
+        }
+        return new FixedTransaction(actions)
+    }
+
+    /**
+     * Scripted executor: per-action outcomes come from {@code outcomes} (keyed by actionId), the
+     * session and provider resolution are fixed. Follows the subclass-with-override pattern from
+     * {@link TransactionExecutorChangesSpec}.
+     */
+    private TransactionExecutorImpl newExecutor(
+            TransactionsConfiguration cfg,
+            RecordingSession session,
+            Map<String, Closure<ActionResult>> outcomes) {
+        return new TransactionExecutorImpl(
+                null, null, null, Stub(FeaturesCoreQueriesHandler), Stub(VolatileRegistry)) {
+            @Override
+            TransactionsConfiguration transactionsConfig(OgcApi api) {
+                return cfg
+            }
+
+            @Override
+            String resolveProviderId(OgcApi api, String collectionId) {
+                return 'p1'
+            }
+
+            @Override
+            String canonicalCollectionId(OgcApi api, String collectionId) {
+                return collectionId
+            }
+
+            @Override
+            FeatureTransactions.Session openSessionFor(OgcApi api, String collectionId) {
+                return session
+            }
+
+            @Override
+            ActionResult runAction(
+                    TxAction action,
+                    FeatureTransactions.Session s,
+                    OgcApi api,
+                    ApiRequestContext ctx,
+                    EpsgCrs requestCrs,
+                    Map<String, Set<String>> touchedIdsByCollection,
+                    Map<String, MutationStrategy> strategyByCollection,
+                    Instant scopeTimestamp,
+                    Optional<Instant> ogcMutationDatetime,
+                    boolean validate,
+                    boolean skipInvalid,
+                    boolean fromWfs) {
+                return outcomes[action.actionId.get()].call()
+            }
+        }
+    }
+
+    private static class FixedTransaction implements Transaction {
+        private final List<TxAction> actions
+
+        FixedTransaction(List<TxAction> actions) {
+            this.actions = actions
+        }
+
+        @Override
+        TxSemantic getSemantic() {
+            return TxSemantic.ATOMIC
+        }
+
+        @Override
+        Iterator<TxAction> actions() {
+            return actions.iterator()
+        }
+
+        @Override
+        void close() {
+        }
+    }
+
+    private static class RecordingSession implements FeatureTransactions.Session {
+        List<String> calls = []
+        List<String> nextWarnings = []
+        boolean savepoints = true
+        RuntimeException throwOnRollbackToSavepoint
+        RuntimeException throwOnCommit
+
+        @Override
+        List<String> drainWarnings() {
+            List<String> drained = nextWarnings
+            nextWarnings = []
+            return drained
+        }
+
+        @Override
+        FeatureTransactions.MutationResult createFeatures(
+                String featureType, FeatureTokenSource source, EpsgCrs crs, Optional<String> featureId) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        FeatureTransactions.MutationResult updateFeature(
+                String type, String id, FeatureTokenSource source, EpsgCrs crs, boolean partial) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        FeatureTransactions.MutationResult deleteFeature(String featureType, String id) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        List<String> execute(List<String> statements) {
+            calls << 'execute'
+            return []
+        }
+
+        @Override
+        boolean supportsSavepoints() {
+            return savepoints
+        }
+
+        @Override
+        void savepoint() {
+            calls << 'savepoint'
+        }
+
+        @Override
+        void releaseSavepoint() {
+            calls << 'release'
+        }
+
+        @Override
+        void rollbackToSavepoint() {
+            calls << 'rollbackTo'
+            if (throwOnRollbackToSavepoint != null) {
+                throw throwOnRollbackToSavepoint
+            }
+        }
+
+        @Override
+        void commit() {
+            calls << 'commit'
+            if (throwOnCommit != null) {
+                throw throwOnCommit
+            }
+        }
+
+        @Override
+        void rollback() {
+            calls << 'rollback'
+        }
+
+        @Override
+        void close() {
+            calls << 'close'
+        }
+    }
+}


### PR DESCRIPTION
### Pull request checklist

-   [x] Added/updated unit tests
-   [x] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

Depends on https://github.com/ldproxy/xtraplatform-spatial/pull/584.

Changes:

- new TRANSACTIONS option `collectErrors` (default `false`): a failing action no longer stops an atomic transaction — every action runs inside a database savepoint, all errors are collected and reported in the response, and all changes are still rolled back; falls back to stop-at-first-error when the provider session does not support savepoints
- new action status `ROLLED_BACK`: in a failed atomic transaction, actions that succeeded before the rollback no longer render as successes (the 422 body listed their feature URIs and counted them in summary)
- transaction-level errors (failed commit or pre-commit hook) are reported as a single exception instead of one duplicated exception per action
- summary gains `totalFailed`, `totalRolledBack` and `totalSkipped`
- exceptions and error texts use the canonical API collection id instead of the raw type name from the request
- per-action SQL warnings (RAISE WARNING / RAISE NOTICE from triggers or functions) are drained from the provider session and returned in warnings, prefixed with the action label
- specs for the atomic execution loop (savepoint lifecycle, error collection, fatal-error skipping, fallback) and the response rendering
