### PR TITLE
gml: encode object properties as XML element chains

### DIFF
--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/UpdatePathResolver.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/UpdatePathResolver.java
@@ -230,9 +230,15 @@ final class UpdatePathResolver {
     return segment.trim().endsWith("/");
   }
 
-  /** The local name of a chain segment: its {@code prefix:} and attribute predicates removed. */
+  /**
+   * The local name of a chain segment: its repetition marker (leading {@code *}), {@code prefix:}
+   * and attribute predicates removed.
+   */
   private static String localName(String segment) {
     String name = segment.trim();
+    if (name.startsWith("*")) {
+      name = name.substring(1).trim();
+    }
     int bracket = name.indexOf('[');
     if (bracket >= 0) {
       name = name.substring(0, bracket).trim();

--- a/ogcapi-draft/ogcapi-transactions/src/test/groovy/de/ii/ogcapi/transactions/app/UpdatePathResolverSpec.groovy
+++ b/ogcapi-draft/ogcapi-transactions/src/test/groovy/de/ii/ogcapi/transactions/app/UpdatePathResolverSpec.groovy
@@ -231,6 +231,26 @@ class UpdatePathResolverSpec extends Specification {
         resolved*.getName() == ["gwt"]
     }
 
+    def "an xmlPaths chain segment with a repetition marker matches on its local name"() {
+        given:
+        // The '*' names the segment an object-array chain repeats from; the ValueReference
+        // carries the plain element name.
+        def root = feature(scalar("q2d_gst"))
+        def xmlPaths = ["q2d_gst": ["qualitaetsangaben", "AX_DQPunktort", "herkunft",
+                                    "gmd:LI_Lineage", "*gmd:processStep", "gmd:LI_ProcessStep",
+                                    "gmd:description", "AX_Description"]]
+
+        when:
+        def resolved = UpdatePathResolver.resolve(
+                root,
+                ["qualitaetsangaben", "AX_DQPunktort", "herkunft", "LI_Lineage", "processStep",
+                 "LI_ProcessStep", "description", "AX_Description"],
+                false, true, xmlPaths)
+
+        then:
+        resolved*.getName() == ["q2d_gst"]
+    }
+
     def "a path addressing only part of an xmlPaths chain is rejected with the full chain"() {
         given:
         def root = feature(scalar("lzi_beg", null, SchemaBase.Type.DATETIME))

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/GmlWriterProperties.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/GmlWriterProperties.java
@@ -68,6 +68,13 @@ public class GmlWriterProperties implements GmlWriter {
     if (context.schema().filter(FeatureSchema::isObject).isPresent()) {
       FeatureSchema schema = context.schema().orElseThrow();
 
+      if (isXmlPathObject(context, schema)) {
+        // the chain contributes both the property element and the object element; it was opened
+        // by GmlWriterXmlPaths, which runs before this writer
+        next.accept(context);
+        return;
+      }
+
       String elementNameProperty =
           context
               .encoding()
@@ -124,6 +131,11 @@ public class GmlWriterProperties implements GmlWriter {
   public void onObjectEnd(EncodingAwareContextGml context, Consumer<EncodingAwareContextGml> next)
       throws IOException {
     if (context.schema().filter(FeatureSchema::isObject).isPresent()) {
+      if (isXmlPathObject(context, context.schema().orElseThrow())) {
+        // closed by GmlWriterXmlPaths together with the members' own wrappers
+        next.accept(context);
+        return;
+      }
       boolean inLink = context.encoding().getState().getInLink();
       boolean inMeasure = context.encoding().getState().getInMeasure();
 
@@ -248,41 +260,20 @@ public class GmlWriterProperties implements GmlWriter {
     XmlPathElement valueElement = chain.get(chain.size() - 1);
     String path = schema.getFullPathAsString();
 
-    List<XmlPathElement> open = state.getXmlPathOpenPrefix();
-    int shared = 0;
-    if (state.getXmlPathOwner().filter(path::equals).isEmpty()) {
-      while (shared < open.size()
-          && shared < prefix.size()
-          && open.get(shared).equals(prefix.get(shared))) {
-        shared++;
-      }
-    }
-    for (int i = open.size() - 1; i >= shared; i--) {
-      if (!open.get(i).isEmptyElement()) {
-        context.encoding().writeEndElement();
-      }
-    }
+    int shared = XmlPathWriter.closeToShared(context.encoding(), prefix, path, true);
     for (int i = shared; i < prefix.size(); i++) {
       XmlPathElement element = prefix.get(i);
-      context.encoding().writeStartElement(element.getName());
-      for (Map.Entry<String, String> attribute : element.getAttributes().entrySet()) {
-        context.encoding().writeAttribute(attribute.getKey(), attribute.getValue());
-      }
-      if (element.isEmptyElement()) {
-        // injected constant element (e.g. ISO 19139 valueUnit) — closed immediately, the chain
-        // continues inside the enclosing wrapper
-        context.encoding().writeEndElement();
-      } else {
+      // an injected constant element (e.g. ISO 19139 valueUnit) is written and closed right away,
+      // and the chain continues inside the enclosing wrapper
+      XmlPathWriter.writeElement(context.encoding(), element);
+      if (!element.isEmptyElement()) {
         writeIso19139CodeListAttributes(context, schema, element.getName(), value);
       }
     }
     state.setXmlPathOpenPrefix(ImmutableList.copyOf(prefix));
     state.setXmlPathOwner(Optional.of(path));
 
-    context.encoding().writeStartElement(valueElement.getName());
-    for (Map.Entry<String, String> attribute : valueElement.getAttributes().entrySet()) {
-      context.encoding().writeAttribute(attribute.getKey(), attribute.getValue());
-    }
+    XmlPathWriter.writeElement(context.encoding(), valueElement);
     // the unit qualifies the value, so it belongs on the element that carries it — the innermost
     // segment of the chain, exactly where a gml:MeasureType expects it
     writeUnitIfNecessary(context, schema);

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/GmlWriterXmlPaths.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/GmlWriterXmlPaths.java
@@ -10,9 +10,11 @@ package de.ii.ogcapi.features.gml.app;
 import com.github.azahnen.dagger.annotations.AutoBind;
 import de.ii.ogcapi.features.gml.domain.EncodingAwareContextGml;
 import de.ii.ogcapi.features.gml.domain.GmlWriter;
+import de.ii.xtraplatform.features.domain.FeatureSchema;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 /**
@@ -23,6 +25,10 @@ import java.util.function.Consumer;
  * GmlWriterPositionVariants} (25) and {@code GmlWriterGeometry} (30); unmapped value properties are
  * handled by {@code GmlWriterProperties} itself, and the feature end element is written by {@code
  * GmlWriterSkeleton} only after the writer chain has completed.
+ *
+ * <p>An object property that is itself mapped by a chain is the exception: instead of closing the
+ * wrappers, this writer opens the object's chain and closes it again at the object's end, so that
+ * {@code GmlWriterProperties} contributes neither the property element nor the object element.
  */
 @Singleton
 @AutoBind
@@ -44,29 +50,57 @@ public class GmlWriterXmlPaths implements GmlWriter {
   @Override
   public void onObjectStart(EncodingAwareContextGml context, Consumer<EncodingAwareContextGml> next)
       throws IOException {
-    context.encoding().closeXmlPathWrappers();
+    Optional<FeatureSchema> schema = context.schema().filter(FeatureSchema::isObject);
+    if (schema.isPresent() && isXmlPathObject(context, schema.get())) {
+      XmlPathWriter.openObject(
+          context.encoding(),
+          context.encoding().getXmlPaths().get(schema.get().getFullPathAsString()),
+          schema.get());
+    } else {
+      context.encoding().closeXmlPathWrappers();
+    }
     next.accept(context);
   }
 
   @Override
   public void onObjectEnd(EncodingAwareContextGml context, Consumer<EncodingAwareContextGml> next)
       throws IOException {
-    context.encoding().closeXmlPathWrappers();
+    Optional<FeatureSchema> schema = context.schema().filter(FeatureSchema::isObject);
+    if (schema.isPresent()
+        && isXmlPathObject(context, schema.get())
+        && XmlPathWriter.inObject(context.encoding())) {
+      XmlPathWriter.closeObject(context.encoding());
+    } else {
+      context.encoding().closeXmlPathWrappers();
+    }
     next.accept(context);
   }
 
   @Override
   public void onArrayStart(EncodingAwareContextGml context, Consumer<EncodingAwareContextGml> next)
       throws IOException {
-    context.encoding().closeXmlPathWrappers();
+    // an array of chained objects keeps the wrappers its members share open across the array
+    if (!isXmlPathArray(context)) {
+      context.encoding().closeXmlPathWrappers();
+    }
     next.accept(context);
   }
 
   @Override
   public void onArrayEnd(EncodingAwareContextGml context, Consumer<EncodingAwareContextGml> next)
       throws IOException {
-    context.encoding().closeXmlPathWrappers();
+    if (!isXmlPathArray(context)) {
+      context.encoding().closeXmlPathWrappers();
+    }
     next.accept(context);
+  }
+
+  private boolean isXmlPathArray(EncodingAwareContextGml context) {
+    return context
+        .schema()
+        .filter(FeatureSchema::isObject)
+        .filter(schema -> isXmlPathObject(context, schema))
+        .isPresent();
   }
 
   @Override
@@ -80,6 +114,8 @@ public class GmlWriterXmlPaths implements GmlWriter {
   public void onFeatureEnd(EncodingAwareContextGml context, Consumer<EncodingAwareContextGml> next)
       throws IOException {
     context.encoding().closeXmlPathWrappers();
+    // no chain can span features, and the state outlives the feature
+    XmlPathWriter.resetObjects(context.encoding());
     next.accept(context);
   }
 }

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/XmlPathWriter.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/XmlPathWriter.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.features.gml.app;
+
+import com.google.common.collect.ImmutableList;
+import de.ii.ogcapi.features.gml.domain.FeatureTransformationContextGml;
+import de.ii.ogcapi.features.gml.domain.XmlPathElement;
+import de.ii.ogcapi.features.gml.domain.XmlPathObjectFrame;
+import de.ii.xtraplatform.features.domain.FeatureSchema;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Emits the element chains of the {@code xmlPaths} option and maintains the state that lets
+ * consecutive properties share their leading elements. {@code GmlWriterProperties} uses it for
+ * values, {@code GmlWriterXmlPaths} for the objects whose chain replaces the property and object
+ * elements the schema would contribute.
+ */
+final class XmlPathWriter {
+
+  private XmlPathWriter() {}
+
+  /**
+   * Aligns the open wrappers with {@code prefix}: the leading segments both have in common stay
+   * open, every open element below them is closed. Returns the number of shared segments, i.e. the
+   * index from which the caller opens the remainder.
+   *
+   * <p>{@code reopenOnRepeat} decides what a repeated occurrence of {@code path} means. For a value
+   * it shares nothing, so each value of a multi-valued property gets its own wrapper instances. For
+   * an object chain the repetition marker already says which segments repeat, and the segments
+   * before it have to survive from one member to the next.
+   */
+  static int closeToShared(
+      FeatureTransformationContextGml encoding,
+      List<XmlPathElement> prefix,
+      String path,
+      boolean reopenOnRepeat)
+      throws IOException {
+    List<XmlPathElement> open = encoding.getState().getXmlPathOpenPrefix();
+    int shared = 0;
+    if (!reopenOnRepeat || encoding.getState().getXmlPathOwner().filter(path::equals).isEmpty()) {
+      while (shared < open.size()
+          && shared < prefix.size()
+          && open.get(shared).equals(prefix.get(shared))) {
+        shared++;
+      }
+    }
+    for (int i = open.size() - 1; i >= shared; i--) {
+      if (!open.get(i).isEmptyElement()) {
+        encoding.writeEndElement();
+      }
+    }
+    return shared;
+  }
+
+  /**
+   * Writes one chain segment: its start tag with the configured attributes. An injected empty
+   * element (trailing {@code /}) is closed immediately; every other element stays open with its
+   * '&gt;' still pending, so further attributes can be added to it.
+   */
+  static void writeElement(FeatureTransformationContextGml encoding, XmlPathElement element)
+      throws IOException {
+    encoding.writeStartElement(element.getName());
+    for (Map.Entry<String, String> attribute : element.getAttributes().entrySet()) {
+      encoding.writeAttribute(attribute.getKey(), attribute.getValue());
+    }
+    if (element.isEmptyElement()) {
+      encoding.writeEndElement();
+    }
+  }
+
+  /**
+   * Opens the element chain of an object property. The segments before the repetition marker are
+   * merged with the wrappers already open; the segments from the marker on are opened for this
+   * occurrence, the innermost of them holding the object's properties. The enclosing wrapper scope
+   * is saved and the members start with a scope of their own, so their chains merge among
+   * themselves and never close an element belonging to the object.
+   */
+  static void openObject(
+      FeatureTransformationContextGml encoding, List<XmlPathElement> chain, FeatureSchema schema)
+      throws IOException {
+    String path = schema.getFullPathAsString();
+    int repeatAt = repeatIndex(chain);
+    List<XmlPathElement> shared = ImmutableList.copyOf(chain.subList(0, repeatAt));
+    List<XmlPathElement> repeating = ImmutableList.copyOf(chain.subList(repeatAt, chain.size()));
+    int reused = closeToShared(encoding, shared, path, false);
+    for (int i = reused; i < shared.size(); i++) {
+      writeElement(encoding, shared.get(i));
+    }
+    encoding
+        .getState()
+        .setXmlPathObjectStack(
+            ImmutableList.<XmlPathObjectFrame>builder()
+                .addAll(encoding.getState().getXmlPathObjectStack())
+                .add(new XmlPathObjectFrame(shared, repeating, path))
+                .build());
+    for (XmlPathElement element : repeating) {
+      writeElement(encoding, element);
+    }
+    // the innermost element takes the role of the object element: push the object so that the
+    // members' XML-attribute placeholder is anchored to it and not to the enclosing object. The
+    // element name startGmlObject derives is not used — the chain already wrote the element.
+    encoding.startGmlObject(schema);
+    encoding.writeXmlAttPlaceholder();
+    encoding.closeStartElement();
+    encoding.getState().setXmlPathOpenPrefix(ImmutableList.of());
+    encoding.getState().setXmlPathOwner(Optional.empty());
+  }
+
+  /**
+   * Closes the element chain of an object property opened by {@link #openObject}: the members' own
+   * wrappers first, then the repeated segments. The shared segments stay open for the next member
+   * and for a following property whose chain starts the same way.
+   */
+  static void closeObject(FeatureTransformationContextGml encoding) throws IOException {
+    List<XmlPathObjectFrame> stack = encoding.getState().getXmlPathObjectStack();
+    XmlPathObjectFrame frame = stack.get(stack.size() - 1);
+    encoding.closeXmlPathWrappers();
+    for (int i = frame.getRepeating().size() - 1; i >= 0; i--) {
+      if (!frame.getRepeating().get(i).isEmptyElement()) {
+        encoding.writeEndElement();
+      }
+    }
+    encoding.closeGmlObject();
+    encoding
+        .getState()
+        .setXmlPathObjectStack(ImmutableList.copyOf(stack.subList(0, stack.size() - 1)));
+    encoding.getState().setXmlPathOpenPrefix(frame.getShared());
+    encoding.getState().setXmlPathOwner(Optional.of(frame.getPath()));
+  }
+
+  /** Whether an object chain is currently open, i.e. whether {@link #closeObject} has a frame. */
+  static boolean inObject(FeatureTransformationContextGml encoding) {
+    return !encoding.getState().getXmlPathObjectStack().isEmpty();
+  }
+
+  /** Drops the open object chains at the feature boundary, which no chain may cross. */
+  static void resetObjects(FeatureTransformationContextGml encoding) {
+    encoding.getState().setXmlPathObjectStack(ImmutableList.of());
+  }
+
+  /** The segment the chain repeats from; without a marker the whole chain repeats. */
+  private static int repeatIndex(List<XmlPathElement> chain) {
+    for (int i = 0; i < chain.size(); i++) {
+      if (chain.get(i).repeats()) {
+        return i;
+      }
+    }
+    return 0;
+  }
+}

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/FeatureTransformationContextGml.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/FeatureTransformationContextGml.java
@@ -1028,6 +1028,17 @@ public abstract class FeatureTransformationContextGml implements FeatureTransfor
      */
     public abstract Optional<String> getXmlPathOwner();
 
+    /**
+     * The chain of object properties whose {@code xmlPaths} elements are currently open, innermost
+     * last. Each frame holds the wrapper state of the scope enclosing the object, so the object's
+     * members merge their own chains among themselves and the enclosing scope resumes when the
+     * object ends.
+     */
+    @Value.Default
+    public List<XmlPathObjectFrame> getXmlPathObjectStack() {
+      return ImmutableList.of();
+    }
+
     @Value.Default
     public boolean getInGeometry() {
       return false;

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/GmlConfiguration.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/GmlConfiguration.java
@@ -1017,7 +1017,12 @@ public interface GmlConfiguration
    *     single `AA_Lebenszeitintervall` object, in the order of the provider schema. The shared
    *     elements are closed when an unmapped property, a property with a different chain prefix, an
    *     object or array boundary, a geometry, or the feature end follows. For a property with
-   *     multiple values, the full chain is repeated for each value.
+   *     multiple values, the full chain is repeated for each value. An object property can be
+   *     mapped as well: its chain replaces both the property element and the object element, the
+   *     innermost element holds the object's properties, and their own chains are relative to it.
+   *     For an array of objects, a leading `*` on a segment marks where the chain starts repeating:
+   *     the segments before it wrap the array as a whole and are written once, the segments from it
+   *     are written again for every member. Without the marker the whole chain repeats.
    * @langDe Bildet Eigenschaftspfade (Eigenschafts-IDs; entsprechend
    *     `FeatureSchema#getFullPathAsString()` zum Kodierungszeitpunkt, d.h. nach eventuellen
    *     `rename`-Transformationen) auf die vollständige Kette von XML-Elementen ab (von außen nach
@@ -1042,7 +1047,14 @@ public interface GmlConfiguration
    *     Reihenfolge des Provider-Schemas. Die geteilten Elemente werden geschlossen, sobald eine
    *     nicht abgebildete Eigenschaft, eine Eigenschaft mit einem anderen Kettenanfang, eine
    *     Objekt- oder Array-Grenze, eine Geometrie oder das Ende des Features folgt. Bei einer
-   *     Eigenschaft mit mehreren Werten wird die vollständige Kette für jeden Wert wiederholt.
+   *     Eigenschaft mit mehreren Werten wird die vollständige Kette für jeden Wert wiederholt. Auch
+   *     eine Objekt-Eigenschaft kann abgebildet werden: Ihre Kette ersetzt sowohl das
+   *     Eigenschaftselement als auch das Objektelement, das innerste Element enthält die
+   *     Eigenschaften des Objekts, deren eigene Ketten relativ dazu sind. Bei einem Array von
+   *     Objekten markiert ein vorangestelltes `*` an einem Segment, ab wo sich die Kette
+   *     wiederholt: Die Segmente davor umschließen das gesamte Array und werden einmal geschrieben,
+   *     die Segmente ab dem markierten für jedes Element erneut. Ohne Markierung wiederholt sich
+   *     die gesamte Kette.
    * @default {}
    * @examplesAll <code>
    * ```yaml
@@ -1075,6 +1087,16 @@ public interface GmlConfiguration
    *       - gmd:valueUnit[xlink:href=urn:adv:uom:m]/
    *       - gmd:value
    *       - gco:Record[xsi:type=gml:doubleList]
+   *     q2d_dpl_prs:
+   *       - qualitaetsangaben
+   *       - AX_DQPunktort
+   *       - herkunft
+   *       - gmd:LI_Lineage
+   *       - '*gmd:processStep'
+   *       - gmd:LI_ProcessStep
+   *     q2d_dpl_prs.zpe:
+   *       - gmd:dateTime
+   *       - gco:DateTime
    * ```
    * </code>
    * @since v4.8
@@ -1135,6 +1157,7 @@ public interface GmlConfiguration
                     String.format(
                         "GML configuration: the xmlPaths chain for property '%s' is empty", path));
               }
+              boolean repeatSeen = false;
               for (int i = 0; i < chain.size(); i++) {
                 XmlPathElement element;
                 try {
@@ -1150,6 +1173,15 @@ public interface GmlConfiguration
                       String.format(
                           "GML configuration: the innermost xmlPaths segment '%s' for property '%s' must not be an injected empty element (trailing '/')",
                           chain.get(i), path));
+                }
+                if (element.repeats()) {
+                  if (repeatSeen) {
+                    throw new IllegalStateException(
+                        String.format(
+                            "GML configuration: the xmlPaths chain for property '%s' marks more than one segment with '*'; the marker names the single segment from which the chain repeats per array member",
+                            path));
+                  }
+                  repeatSeen = true;
                 }
               }
             });

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/GmlWriter.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/GmlWriter.java
@@ -9,8 +9,30 @@ package de.ii.ogcapi.features.gml.domain;
 
 import com.github.azahnen.dagger.annotations.AutoMultiBind;
 import de.ii.ogcapi.features.core.domain.FeatureWriter;
+import de.ii.xtraplatform.features.domain.FeatureSchema;
+import java.util.List;
+import java.util.Objects;
 
 @AutoMultiBind
 public interface GmlWriter extends FeatureWriter<EncodingAwareContextGml> {
   GmlWriter create();
+
+  /**
+   * Whether an object property is mapped by an {@code xmlPaths} chain. The chain then contributes
+   * both the property element and the object element, and its innermost element holds the object's
+   * properties. Feature references and the {@code Link} and {@code Measure} object types have an
+   * encoding of their own and are never chained, and neither is an object whose element name is
+   * derived from a property value — the chain states that name, so there is nothing to derive.
+   */
+  default boolean isXmlPathObject(EncodingAwareContextGml context, FeatureSchema schema) {
+    String objectType = schema.getObjectType().orElse("");
+    if (schema.isFeatureRef()
+        || "Link".equals(objectType)
+        || "Measure".equals(objectType)
+        || context.encoding().getVariableObjectElementNames().containsKey(objectType)) {
+      return false;
+    }
+    List<XmlPathElement> chain = context.encoding().getXmlPaths().get(schema.getFullPathAsString());
+    return Objects.nonNull(chain) && !chain.isEmpty();
+  }
 }

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/XmlPathElement.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/XmlPathElement.java
@@ -14,23 +14,31 @@ import java.util.Objects;
 
 /**
  * One parsed segment of an {@code xmlPaths} chain. The configured segment syntax is {@code
- * name([attribute=value])*}, optionally followed by a trailing {@code /}: without it the element
+ * [*]name([attribute=value])*}, optionally followed by a trailing {@code /}: without it the element
  * wraps the remainder of the chain (and eventually the property value); with it the element is
  * <em>empty</em> and injected into the chain at its position — written with its attributes and
  * closed immediately, as needed for constant elements like the ISO 19139 {@code valueUnit} child of
  * {@code DQ_QuantitativeResult}, which must precede the {@code value} element. Attribute values may
  * be single- or double-quoted; a {@code ]} inside a value is not supported.
+ *
+ * <p>A leading {@code *} marks the segment from which the chain repeats for each member of an
+ * object array: the segments before it wrap the array as a whole and are written once, the segments
+ * from it are written again for every member. Without the marker the whole chain repeats, which is
+ * what a repeated value needs.
  */
 public final class XmlPathElement {
 
   private final String name;
   private final Map<String, String> attributes;
   private final boolean emptyElement;
+  private final boolean repeats;
 
-  private XmlPathElement(String name, Map<String, String> attributes, boolean emptyElement) {
+  private XmlPathElement(
+      String name, Map<String, String> attributes, boolean emptyElement, boolean repeats) {
     this.name = name;
     this.attributes = Collections.unmodifiableMap(attributes);
     this.emptyElement = emptyElement;
+    this.repeats = repeats;
   }
 
   /**
@@ -40,6 +48,10 @@ public final class XmlPathElement {
    */
   public static XmlPathElement parse(String entry) {
     String s = Objects.requireNonNullElse(entry, "").trim();
+    boolean repeats = s.startsWith("*");
+    if (repeats) {
+      s = s.substring(1).trim();
+    }
     boolean emptyElement = s.endsWith("/");
     if (emptyElement) {
       s = s.substring(0, s.length() - 1).trim();
@@ -80,7 +92,7 @@ public final class XmlPathElement {
       }
       pos = close + 1;
     }
-    return new XmlPathElement(name, attributes, emptyElement);
+    return new XmlPathElement(name, attributes, emptyElement, repeats);
   }
 
   private static String unquote(String value) {
@@ -106,6 +118,11 @@ public final class XmlPathElement {
     return emptyElement;
   }
 
+  /** {@code true} for the segment (leading {@code *}) from which the chain repeats per member. */
+  public boolean repeats() {
+    return repeats;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof XmlPathElement)) {
@@ -114,17 +131,22 @@ public final class XmlPathElement {
     XmlPathElement other = (XmlPathElement) o;
     return name.equals(other.name)
         && attributes.equals(other.attributes)
-        && emptyElement == other.emptyElement;
+        && emptyElement == other.emptyElement
+        && repeats == other.repeats;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, attributes, emptyElement);
+    return Objects.hash(name, attributes, emptyElement, repeats);
   }
 
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder(name);
+    StringBuilder sb = new StringBuilder();
+    if (repeats) {
+      sb.append('*');
+    }
+    sb.append(name);
     attributes.forEach((k, v) -> sb.append('[').append(k).append('=').append(v).append(']'));
     if (emptyElement) {
       sb.append('/');

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/XmlPathObjectFrame.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/domain/XmlPathObjectFrame.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.features.gml.domain;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+
+/**
+ * The open {@code xmlPaths} chain of one object property: the segments before the repetition marker
+ * — shared with the properties following the object and reinstated as the open wrapper prefix when
+ * it ends — and the segments from the marker on, which this occurrence opened and which are closed
+ * again at the object's end.
+ */
+public final class XmlPathObjectFrame {
+
+  private final List<XmlPathElement> shared;
+  private final List<XmlPathElement> repeating;
+  private final String path;
+
+  public XmlPathObjectFrame(
+      List<XmlPathElement> shared, List<XmlPathElement> repeating, String path) {
+    this.shared = ImmutableList.copyOf(shared);
+    this.repeating = ImmutableList.copyOf(repeating);
+    this.path = path;
+  }
+
+  public List<XmlPathElement> getShared() {
+    return shared;
+  }
+
+  public List<XmlPathElement> getRepeating() {
+    return repeating;
+  }
+
+  /** The property path of the object, so a following property can merge with its shared prefix. */
+  public String getPath() {
+    return path;
+  }
+}

--- a/ogcapi-stable/ogcapi-features-gml/src/test/groovy/de/ii/ogcapi/features/gml/app/XmlPathsSpec.groovy
+++ b/ogcapi-stable/ogcapi-features-gml/src/test/groovy/de/ii/ogcapi/features/gml/app/XmlPathsSpec.groovy
@@ -31,6 +31,7 @@ class XmlPathsSpec extends Specification {
         encoding.getState() >> state
         encoding.getXmlAttributes() >> []
         encoding.getCodelistProperties() >> [:]
+        encoding.getVariableObjectElementNames() >> [:]
         encoding.getNamespaces() >> [gmd: 'http://www.isotc211.org/2005/gmd', gco: 'http://www.isotc211.org/2005/gco']
     }
 
@@ -53,6 +54,105 @@ class XmlPathsSpec extends Specification {
             getConstraints() >> Optional.empty()
         }
         return schema
+    }
+
+    private FeatureSchema objectSchema(String name, String path) {
+        def schema = Stub(FeatureSchema) {
+            isObject() >> true
+            isValue() >> false
+            isFeatureRef() >> false
+            getName() >> name
+            getType() >> Type.OBJECT_ARRAY
+            getObjectType() >> Optional.empty()
+            getFullPathAsString() >> path
+        }
+        return schema
+    }
+
+    def 'the chain of an object array wraps the array once and repeats from the marked segment'() {
+        given: 'an object array whose chain is shared down to LI_Lineage and repeats from processStep'
+        encoding.getXmlPaths() >> [
+                'prs'    : chain('qualitaetsangaben', 'AX_DQPunktort', 'herkunft', 'gmd:LI_Lineage', '*gmd:processStep', 'gmd:LI_ProcessStep'),
+                'prs.zpe': chain('gmd:dateTime', 'gco:DateTime')]
+
+        def array = objectSchema('prs', 'prs')
+        def member = valueSchema('zpe', 'prs.zpe', Type.DATETIME)
+        def boundary = new GmlWriterXmlPaths()
+        def properties = new GmlWriterProperties()
+
+        when: 'two members are encoded'
+        boundary.onArrayStart(contextFor(array, null), {} as Consumer)
+        boundary.onObjectStart(contextFor(array, null), {} as Consumer)
+        properties.onValue(contextFor(member, '2008-08-26T00:00:00Z'), {} as Consumer)
+        boundary.onObjectEnd(contextFor(array, null), {} as Consumer)
+        boundary.onObjectStart(contextFor(array, null), {} as Consumer)
+        properties.onValue(contextFor(member, '2015-12-01T00:00:00Z'), {} as Consumer)
+        boundary.onObjectEnd(contextFor(array, null), {} as Consumer)
+        boundary.onArrayEnd(contextFor(array, null), {} as Consumer)
+
+        then: 'the segments before the marker are written once, the segments from it per member'
+        1 * encoding.writeStartElement('qualitaetsangaben')
+        1 * encoding.writeStartElement('AX_DQPunktort')
+        1 * encoding.writeStartElement('herkunft')
+        1 * encoding.writeStartElement('gmd:LI_Lineage')
+        2 * encoding.writeStartElement('gmd:processStep')
+        2 * encoding.writeStartElement('gmd:LI_ProcessStep')
+
+        and: 'the members are encoded inside the innermost element, their own chains relative to it'
+        2 * encoding.writeStartElement('gmd:dateTime')
+        2 * encoding.writeStartElement('gco:DateTime')
+        1 * encoding.writeCharacters('2008-08-26T00:00:00Z')
+        1 * encoding.writeCharacters('2015-12-01T00:00:00Z')
+
+        and: 'per member the value element and the two repeated segments are closed'
+        6 * encoding.writeEndElement()
+
+        and: 'the array boundary leaves the wrappers alone; only the members own scope is closed'
+        2 * encoding.closeXmlPathWrappers()
+
+        and: 'the shared segments stay open for whatever follows the array'
+        state.getXmlPathOpenPrefix().collect { it.getName() } == ['qualitaetsangaben', 'AX_DQPunktort', 'herkunft', 'gmd:LI_Lineage']
+    }
+
+    def 'a property following a chained object array merges into the segments they share'() {
+        given:
+        encoding.getXmlPaths() >> [
+                'prs'    : chain('qualitaetsangaben', 'AX_DQPunktort', 'herkunft', 'gmd:LI_Lineage', '*gmd:processStep', 'gmd:LI_ProcessStep'),
+                'q2d_gst': chain('qualitaetsangaben', 'AX_DQPunktort', 'genauigkeitsstufe')]
+
+        def array = objectSchema('prs', 'prs')
+        def boundary = new GmlWriterXmlPaths()
+
+        when:
+        boundary.onObjectStart(contextFor(array, null), {} as Consumer)
+        boundary.onObjectEnd(contextFor(array, null), {} as Consumer)
+        new GmlWriterProperties().onValue(contextFor(valueSchema('q2d_gst', 'q2d_gst'), '2000'), {} as Consumer)
+
+        then: 'only the two segments the following property does not share are closed'
+        1 * encoding.writeStartElement('qualitaetsangaben')
+        1 * encoding.writeStartElement('AX_DQPunktort')
+        1 * encoding.writeStartElement('genauigkeitsstufe')
+        1 * encoding.writeCharacters('2000')
+
+        and:
+        state.getXmlPathOpenPrefix().collect { it.getName() } == ['qualitaetsangaben', 'AX_DQPunktort']
+    }
+
+    def 'a chained object contributes neither its property element nor its object element'() {
+        given:
+        encoding.getXmlPaths() >> ['prs': chain('herkunft', 'gmd:LI_Lineage', '*gmd:processStep', 'gmd:LI_ProcessStep')]
+
+        def array = objectSchema('prs', 'prs')
+        def writer = new GmlWriterProperties()
+
+        when: 'the property writer sees the object boundaries of a chained object'
+        writer.onObjectStart(contextFor(array, null), {} as Consumer)
+        writer.onObjectEnd(contextFor(array, null), {} as Consumer)
+
+        then: 'it writes nothing — the chain already carries both elements'
+        0 * encoding.writeStartElement(_)
+        0 * encoding.writeEndElement()
+        0 * encoding.startGmlObject(_)
     }
 
     def 'the uom of a chained property goes on the innermost element'() {

--- a/ogcapi-stable/ogcapi-features-gml/src/test/groovy/de/ii/ogcapi/features/gml/domain/XmlPathElementSpec.groovy
+++ b/ogcapi-stable/ogcapi-features-gml/src/test/groovy/de/ii/ogcapi/features/gml/domain/XmlPathElementSpec.groovy
@@ -21,16 +21,24 @@ class XmlPathElementSpec extends Specification {
         el.getName() == name
         el.getAttributes() == attributes
         el.isEmptyElement() == emptyElement
+        el.repeats() == repeats
 
         where:
-        entry                                        || name            | attributes                      | emptyElement
-        'beginnt'                                    || 'beginnt'       | [:]                             | false
-        'gco:Record'                                 || 'gco:Record'    | [:]                             | false
-        'gco:Record[xsi:type=gml:doubleList]'        || 'gco:Record'    | ['xsi:type': 'gml:doubleList']  | false
-        'gmd:valueUnit[xlink:href=urn:adv:uom:m]/'   || 'gmd:valueUnit' | ['xlink:href': 'urn:adv:uom:m'] | true
-        "gmd:valueUnit[xlink:href='urn:adv:uom:m']/" || 'gmd:valueUnit' | ['xlink:href': 'urn:adv:uom:m'] | true
-        'el[a=1][b=two words]'                       || 'el'            | ['a': '1', 'b': 'two words']    | false
-        'el/'                                        || 'el'            | [:]                             | true
+        entry                                        || name              | attributes                      | emptyElement | repeats
+        'beginnt'                                    || 'beginnt'         | [:]                             | false        | false
+        'gco:Record'                                 || 'gco:Record'      | [:]                             | false        | false
+        'gco:Record[xsi:type=gml:doubleList]'        || 'gco:Record'      | ['xsi:type': 'gml:doubleList']  | false        | false
+        'gmd:valueUnit[xlink:href=urn:adv:uom:m]/'   || 'gmd:valueUnit'   | ['xlink:href': 'urn:adv:uom:m'] | true         | false
+        "gmd:valueUnit[xlink:href='urn:adv:uom:m']/" || 'gmd:valueUnit'   | ['xlink:href': 'urn:adv:uom:m'] | true         | false
+        'el[a=1][b=two words]'                       || 'el'              | ['a': '1', 'b': 'two words']    | false        | false
+        'el/'                                        || 'el'              | [:]                             | true         | false
+        '*gmd:processStep'                           || 'gmd:processStep' | [:]                             | false        | true
+        '*el[a=1]'                                   || 'el'              | ['a': '1']                      | false        | true
+    }
+
+    def 'the repetition marker is part of a segments identity'() {
+        expect: 'sharing a wrapper compares segments, and a repeated one is not the same element'
+        XmlPathElement.parse('*gmd:processStep') != XmlPathElement.parse('gmd:processStep')
     }
 
     @Unroll
@@ -51,6 +59,6 @@ class XmlPathElementSpec extends Specification {
         XmlPathElement.parse(entry).toString() == entry
 
         where:
-        entry << ['beginnt', 'gco:Record[xsi:type=gml:doubleList]', 'gmd:valueUnit[xlink:href=urn:adv:uom:m]/']
+        entry << ['beginnt', 'gco:Record[xsi:type=gml:doubleList]', 'gmd:valueUnit[xlink:href=urn:adv:uom:m]/', '*gmd:processStep']
     }
 }


### PR DESCRIPTION
### Pull request checklist

-   [x] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

Follow-up to #1706. Depends on https://github.com/ldproxy/xtraplatform-spatial/pull/587.

An xmlPaths chain may map an object property: the chain replaces both the property element and the object element, its innermost element holds the object's properties, and their own chains are relative to it. For an array of objects a leading '*' marks the segment from which the chain repeats per member: the segments before it wrap the array as a whole and are written once, the segments from it are written again for every member. Consecutive properties sharing leading segments continue to share those elements across an object chain.

- XmlPathElement parses the repetition marker; the configuration check rejects more than one marked segment per chain.
- XmlPathWriter opens, shares and closes the chain elements of values and objects; GmlWriterXmlPaths opens an object's chain at the object boundary and closes it at the object's end instead of closing the open wrappers; GmlWriterProperties contributes neither the property element nor the object element for a chained object.
- Objects with variable element names, feature references and the Link and Measure object types keep their own encoding and are never chained.
- The transactions path resolver ignores the marker when matching an input property path against a chain.
