### PR TITLE
fix profile crs-original

### DIFF
--- a/ogcapi-custom/ogcapi-profile-crs/build.gradle
+++ b/ogcapi-custom/ogcapi-profile-crs/build.gradle
@@ -1,11 +1,12 @@
 
 maturity = 'PROPOSAL'
 maintenance = 'NONE'
-description = 'Profile for positions stored in a reference system that differs from the storage CRS.'
-descriptionDe = 'Profil für Positionen, die in einem anderen Referenzsystem als dem Speicher-CRS gespeichert sind.'
+description = 'Profiles for the reference system of the positions in the response.'
+descriptionDe = 'Profile für das Referenzsystem der Positionen in der Antwort.'
 
 
 dependencies {
+    provided 'de.interactive_instruments:xtraplatform-crs'
     provided 'de.interactive_instruments:xtraplatform-features'
     provided 'de.interactive_instruments:ogcapi-features-core'
 }

--- a/ogcapi-custom/ogcapi-profile-crs/src/main/java/de/ii/ogcapi/profile/crs/app/ProfileCrsBuildingBlock.java
+++ b/ogcapi-custom/ogcapi-profile-crs/src/main/java/de/ii/ogcapi/profile/crs/app/ProfileCrsBuildingBlock.java
@@ -19,44 +19,59 @@ import java.util.Optional;
 
 /**
  * @title Profile - Position CRS
- * @langEn Profiles for positions stored in a reference system that differs from the storage CRS.
- * @langDe Profile für Positionen, die in einem anderen Referenzsystem als dem Speicher-CRS
- *     gespeichert sind.
- * @scopeEn If the feature schema includes at least one geometry property with a `variants`
- *     declaration, one of two profiles can be used to select the representation of these positions
- *     in the response. With "crs-original", positions are represented as recorded: in their
- *     original reference system, identified by the stored verbatim CRS identifier, unaffected by
- *     the `crs` query parameter. This includes positions in reference systems that cannot be
- *     expressed as the CRS of the response, such as realizations that map to the same coordinate
- *     reference system or 1D vertical reference systems.
+ * @langEn Profiles for the reference system of the positions in the response.
+ * @langDe Profile für das Referenzsystem der Positionen in der Antwort.
+ * @scopeEn One of two profiles can be used to select the reference system of the positions in the
+ *     response.
+ *     <p>With "crs-original", positions are represented as recorded. A position of a geometry
+ *     property with a `crsVariants` declaration in the provider schema is returned in its original
+ *     reference system, identified by the stored verbatim CRS identifier. This includes positions
+ *     in reference systems that cannot be expressed as the CRS of the response, such as
+ *     realizations that map to the same coordinate reference system or 1D vertical reference
+ *     systems. Every other position is returned in the CRS in which the feature provider stores it,
+ *     that is, in the storage CRS of the collection.
  *     <p>With "crs-requested" (the default), the position of the primary geometry property is
  *     returned in the requested CRS in all feature encodings; a feature whose position cannot be
  *     represented in the requested CRS (for example, a position in a 1D vertical reference system)
  *     is returned without a geometry.
- *     <p>The profile is supported by GML (the position element carries the original identifier as
- *     `srsName`, 1D positions are encoded with `srsDimension="1"`) and by GeoJSON with the JSON-FG
+ *     <p>The CRS that "crs-original" selects is a fallback for the default CRS of the API: if the
+ *     request includes a `crs` parameter, the positions are returned in that CRS, except for the
+ *     positions of a geometry property with a `crsVariants` declaration, which are always returned
+ *     as recorded. In the HTML representation the profile is ignored, as is the `crs` parameter.
+ *     <p>The original reference system of a position of a geometry property with a `crsVariants`
+ *     declaration is represented in GML (the position element carries the original identifier as
+ *     `srsName`, 1D positions are encoded with `srsDimension="1"`) and in GeoJSON with the JSON-FG
  *     extensions (`place` carries the original position with the identifier in `coordRefSys`; for a
  *     1D position, the vertical coordinate and the identifier appear in `properties`). Feature
  *     encodings that cannot represent positions in other reference systems (for example, plain
- *     GeoJSON) ignore the profile.
- * @scopeDe Wenn das Feature-Schema mindestens eine Geometrieeigenschaft mit einer
- *     `variants`-Deklaration enthält, kann eines von zwei Profilen verwendet werden, um die
- *     Darstellung dieser Positionen in der Antwort auszuwählen. Mit "crs-original" werden die
- *     Positionen wie erfasst dargestellt: in ihrem ursprünglichen Referenzsystem, identifiziert
- *     durch die unverändert gespeicherte CRS-Kennung, unabhängig vom Query-Parameter `crs`. Dies
- *     schließt Positionen in Referenzsystemen ein, die nicht als CRS der Antwort ausgedrückt werden
- *     können, etwa Realisierungen, die auf dasselbe Koordinatenreferenzsystem abgebildet werden,
- *     oder eindimensionale Höhenreferenzsysteme.
+ *     GeoJSON) return such positions in the CRS of the response.
+ * @scopeDe Es kann eines von zwei Profilen verwendet werden, um das Referenzsystem der Positionen
+ *     in der Antwort auszuwählen.
+ *     <p>Mit "crs-original" werden die Positionen wie erfasst dargestellt. Eine Position einer
+ *     Geometrieeigenschaft mit einer `crsVariants`-Deklaration im Provider-Schema wird in ihrem
+ *     ursprünglichen Referenzsystem zurückgegeben, identifiziert durch die unverändert gespeicherte
+ *     CRS-Kennung. Dies schließt Positionen in Referenzsystemen ein, die nicht als CRS der Antwort
+ *     ausgedrückt werden können, etwa Realisierungen, die auf dasselbe Koordinatenreferenzsystem
+ *     abgebildet werden, oder eindimensionale Höhenreferenzsysteme. Alle anderen Positionen werden
+ *     in dem CRS zurückgegeben, in dem der Feature-Provider sie speichert, also im Speicher-CRS der
+ *     Collection.
  *     <p>Mit "crs-requested" (dem Default) wird die Position der Haupt-Geometrieeigenschaft in
  *     allen Feature-Kodierungen im angeforderten CRS zurückgegeben; ein Feature, dessen Position
  *     nicht im angeforderten CRS dargestellt werden kann (zum Beispiel eine Position in einem
  *     eindimensionalen Höhenreferenzsystem), wird ohne Geometrie zurückgegeben.
- *     <p>Das Profil wird von GML unterstützt (das Positionselement führt die ursprüngliche Kennung
- *     als `srsName`, 1D-Positionen werden mit `srsDimension="1"` kodiert) sowie von GeoJSON mit den
+ *     <p>Das CRS, das "crs-original" auswählt, ist ein Fallback für das Standard-CRS der API: Wenn
+ *     die Anfrage einen `crs`-Parameter enthält, werden die Positionen in diesem CRS zurückgegeben,
+ *     mit Ausnahme der Positionen einer Geometrieeigenschaft mit einer `crsVariants`-Deklaration,
+ *     die immer wie erfasst zurückgegeben werden. In der HTML-Ausgabe wird das Profil ignoriert,
+ *     ebenso wie der `crs`-Parameter.
+ *     <p>Das ursprüngliche Referenzsystem einer Position einer Geometrieeigenschaft mit einer
+ *     `crsVariants`-Deklaration wird in GML (das Positionselement führt die ursprüngliche Kennung
+ *     als `srsName`, 1D-Positionen werden mit `srsDimension="1"` kodiert) sowie in GeoJSON mit den
  *     JSON-FG-Erweiterungen (`place` enthält die ursprüngliche Position mit der Kennung in
  *     `coordRefSys`; bei einer 1D-Position erscheinen die Höhenkoordinate und die Kennung in
- *     `properties`). Feature-Kodierungen, die Positionen in anderen Referenzsystemen nicht
- *     darstellen können (zum Beispiel reines GeoJSON), ignorieren das Profil.
+ *     `properties`) dargestellt. Feature-Kodierungen, die Positionen in anderen Referenzsystemen
+ *     nicht darstellen können (zum Beispiel reines GeoJSON), geben diese Positionen im CRS der
+ *     Antwort zurück.
  * @ref:cfg {@link de.ii.ogcapi.profile.crs.domain.ProfileCrsConfiguration}
  * @ref:cfgProperties {@link de.ii.ogcapi.profile.crs.domain.ImmutableProfileCrsConfiguration}
  */

--- a/ogcapi-custom/ogcapi-profile-crs/src/main/java/de/ii/ogcapi/profile/crs/app/ProfileCrsOriginal.java
+++ b/ogcapi-custom/ogcapi-profile-crs/src/main/java/de/ii/ogcapi/profile/crs/app/ProfileCrsOriginal.java
@@ -8,30 +8,42 @@
 package de.ii.ogcapi.profile.crs.app;
 
 import com.github.azahnen.dagger.annotations.AutoBind;
+import de.ii.ogcapi.features.core.domain.FeaturesCoreProviders;
+import de.ii.ogcapi.features.core.domain.ProfileResponseCrs;
 import de.ii.ogcapi.foundation.domain.ExtensionConfiguration;
 import de.ii.ogcapi.foundation.domain.ExtensionRegistry;
+import de.ii.ogcapi.foundation.domain.OgcApiDataV2;
 import de.ii.ogcapi.foundation.domain.ProfileGeneric;
 import de.ii.ogcapi.profile.crs.domain.ProfileCrsConfiguration;
+import de.ii.xtraplatform.crs.domain.EpsgCrs;
+import de.ii.xtraplatform.features.domain.FeatureCrs;
+import de.ii.xtraplatform.features.domain.FeatureProvider;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.util.Optional;
 
 /**
- * Positions of a geometry property with a {@code variants} declaration in the provider schema are
- * represented as recorded: in their original reference system, identified by the stored verbatim
- * CRS identifier, unaffected by the {@code crs} query parameter. Feature encodings that do not
- * support the profile (for example, GeoJSON, which cannot represent other CRSs) ignore it. The
- * profile id is referenced by its literal value in the encoders (for example, {@code
- * GmlWriterPositionVariants}), which must not depend on this module.
+ * Positions are represented as recorded. Positions of a geometry property with a {@code
+ * crsVariants} declaration in the provider schema are returned in their original reference system,
+ * identified by the stored verbatim CRS identifier; every other position is returned in the CRS in
+ * which the feature provider stores it. The CRS of the provider is a fallback for the default CRS
+ * of the API, so a {@code crs} parameter in the request takes precedence; in the HTML
+ * representation the profile is ignored, as is the {@code crs} parameter. The profile id is
+ * referenced by its literal value in the encoders (for example, {@code GmlWriterPositionVariants}),
+ * which must not depend on this module.
  */
 @Singleton
 @AutoBind
-public class ProfileCrsOriginal extends ProfileGeneric {
+public class ProfileCrsOriginal extends ProfileGeneric implements ProfileResponseCrs {
 
   public static final String ID = "crs-original";
 
+  private final FeaturesCoreProviders providers;
+
   @Inject
-  ProfileCrsOriginal(ExtensionRegistry extensionRegistry) {
+  ProfileCrsOriginal(ExtensionRegistry extensionRegistry, FeaturesCoreProviders providers) {
     super(extensionRegistry);
+    this.providers = providers;
   }
 
   @Override
@@ -42,6 +54,16 @@ public class ProfileCrsOriginal extends ProfileGeneric {
   @Override
   public String getProfileSet() {
     return ProfileSetCrs.ID;
+  }
+
+  @Override
+  public Optional<EpsgCrs> getResponseCrs(OgcApiDataV2 apiData, String collectionId) {
+    return apiData
+        .getCollectionData(collectionId)
+        .flatMap(
+            collectionData ->
+                providers.getFeatureProvider(apiData, collectionData, FeatureProvider::crs))
+        .map(FeatureCrs::getNativeCrs);
   }
 
   @Override

--- a/ogcapi-custom/ogcapi-profile-crs/src/main/java/de/ii/ogcapi/profile/crs/app/ProfileCrsRequested.java
+++ b/ogcapi-custom/ogcapi-profile-crs/src/main/java/de/ii/ogcapi/profile/crs/app/ProfileCrsRequested.java
@@ -17,10 +17,11 @@ import jakarta.inject.Singleton;
 
 /**
  * The standard behaviour and the default of the profile set: the position of the primary geometry
- * property is returned in the requested CRS in every feature encoding; positions that cannot be
- * represented in the requested CRS (for example, positions in a 1D vertical reference system) are
- * returned without a geometry. The profile exists so that a client can explicitly select the
- * standard behaviour on an API that declares {@code crs-original} as its default profile.
+ * property is returned in the requested CRS - or in the default CRS of the API, if the request does
+ * not include a {@code crs} parameter - in every feature encoding; positions that cannot be
+ * represented in that CRS (for example, positions in a 1D vertical reference system) are returned
+ * without a geometry. The profile exists so that a client can explicitly select the standard
+ * behaviour on an API that declares {@code crs-original} as its default profile.
  */
 @Singleton
 @AutoBind

--- a/ogcapi-custom/ogcapi-profile-crs/src/main/java/de/ii/ogcapi/profile/crs/app/ProfileSetCrs.java
+++ b/ogcapi-custom/ogcapi-profile-crs/src/main/java/de/ii/ogcapi/profile/crs/app/ProfileSetCrs.java
@@ -9,7 +9,6 @@ package de.ii.ogcapi.profile.crs.app;
 
 import com.github.azahnen.dagger.annotations.AutoBind;
 import de.ii.ogcapi.features.core.domain.FeaturesCoreConfiguration;
-import de.ii.ogcapi.features.core.domain.FeaturesCoreProviders;
 import de.ii.ogcapi.foundation.domain.ExtensionConfiguration;
 import de.ii.ogcapi.foundation.domain.ExtensionRegistry;
 import de.ii.ogcapi.foundation.domain.OgcApiDataV2;
@@ -20,17 +19,22 @@ import jakarta.inject.Singleton;
 import jakarta.ws.rs.core.MediaType;
 import java.util.Set;
 
+/**
+ * The profile set is available for every collection with features, not only for collections with a
+ * {@code crsVariants} declaration in the provider schema: both profiles also determine the CRS of
+ * the positions that are stored in the CRS of the provider. A collection-specific availability
+ * would make the representation of the positions in a query over multiple collections depend on the
+ * collections in the query.
+ */
 @Singleton
 @AutoBind
 public class ProfileSetCrs extends ProfileSet {
 
   public static final String ID = "crs";
-  private final FeaturesCoreProviders providers;
 
   @Inject
-  public ProfileSetCrs(ExtensionRegistry extensionRegistry, FeaturesCoreProviders providers) {
+  public ProfileSetCrs(ExtensionRegistry extensionRegistry) {
     super(extensionRegistry, MediaType.WILDCARD_TYPE);
-    this.providers = providers;
   }
 
   @Override
@@ -41,7 +45,6 @@ public class ProfileSetCrs extends ProfileSet {
   @Override
   public boolean isEnabledForApi(OgcApiDataV2 apiData) {
     return super.isEnabledForApi(apiData)
-        && usesPositionVariants(apiData)
         && apiData
             .getExtension(FeaturesCoreConfiguration.class)
             .map(ExtensionConfiguration::isEnabled)
@@ -51,7 +54,6 @@ public class ProfileSetCrs extends ProfileSet {
   @Override
   public boolean isEnabledForApi(OgcApiDataV2 apiData, String collectionId) {
     return super.isEnabledForApi(apiData, collectionId)
-        && usesPositionVariants(apiData, collectionId)
         && apiData
             .getExtension(FeaturesCoreConfiguration.class, collectionId)
             .map(ExtensionConfiguration::isEnabled)
@@ -66,25 +68,5 @@ public class ProfileSetCrs extends ProfileSet {
   @Override
   public Class<? extends ExtensionConfiguration> getBuildingBlockConfigurationType() {
     return ProfileCrsConfiguration.class;
-  }
-
-  private boolean usesPositionVariants(OgcApiDataV2 apiData) {
-    return apiData.getCollections().keySet().stream()
-        .anyMatch(collectionId -> usesPositionVariants(apiData, collectionId));
-  }
-
-  private boolean usesPositionVariants(OgcApiDataV2 apiData, String collectionId) {
-    return apiData
-        .getCollectionData(collectionId)
-        .map(
-            collectionData ->
-                providers
-                    .getFeatureSchema(apiData, collectionData)
-                    .map(
-                        featureSchema ->
-                            featureSchema.getAllNestedProperties().stream()
-                                .anyMatch(p -> p.getCrsVariants().isPresent()))
-                    .orElse(false))
-        .orElse(false);
   }
 }

--- a/ogcapi-custom/ogcapi-profile-crs/src/test/groovy/de/ii/ogcapi/profile/crs/app/ProfileCrsOriginalSpec.groovy
+++ b/ogcapi-custom/ogcapi-profile-crs/src/test/groovy/de/ii/ogcapi/profile/crs/app/ProfileCrsOriginalSpec.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.profile.crs.app
+
+import de.ii.ogcapi.features.core.domain.FeaturesCoreProviders
+import de.ii.ogcapi.foundation.domain.ExtensionRegistry
+import de.ii.ogcapi.foundation.domain.FeatureTypeConfigurationOgcApi
+import de.ii.ogcapi.foundation.domain.OgcApiDataV2
+import de.ii.xtraplatform.crs.domain.EpsgCrs
+import de.ii.xtraplatform.features.domain.FeatureCrs
+import spock.lang.Specification
+
+class ProfileCrsOriginalSpec extends Specification {
+
+    static final String COLLECTION_ID = 'ax_punktortau'
+    static final EpsgCrs NATIVE_CRS = EpsgCrs.of(25832)
+
+    def 'the response CRS is the CRS of the feature provider'() {
+
+        given: 'a collection whose provider stores the positions in EPSG:25832'
+        def collectionData = Stub(FeatureTypeConfigurationOgcApi)
+        def apiData = Stub(OgcApiDataV2)
+        apiData.getCollectionData(COLLECTION_ID) >> Optional.of(collectionData)
+        def featureCrs = Stub(FeatureCrs)
+        featureCrs.getNativeCrs() >> NATIVE_CRS
+        def providers = Stub(FeaturesCoreProviders)
+        providers.getFeatureProvider(apiData, collectionData, _) >> Optional.of(featureCrs)
+        def profile = new ProfileCrsOriginal(Stub(ExtensionRegistry), providers)
+
+        when: 'the profile is asked for the CRS of the response'
+        def crs = profile.getResponseCrs(apiData, COLLECTION_ID)
+
+        then: 'it is the CRS of the provider, not the default CRS of the API'
+        crs.isPresent()
+        crs.get() == NATIVE_CRS
+    }
+
+    def 'no response CRS without a CRS in the feature provider'() {
+
+        given: 'a collection whose provider does not provide a CRS'
+        def collectionData = Stub(FeatureTypeConfigurationOgcApi)
+        def apiData = Stub(OgcApiDataV2)
+        apiData.getCollectionData(COLLECTION_ID) >> Optional.of(collectionData)
+        def providers = Stub(FeaturesCoreProviders)
+        providers.getFeatureProvider(apiData, collectionData, _) >> Optional.empty()
+        def profile = new ProfileCrsOriginal(Stub(ExtensionRegistry), providers)
+
+        when: 'the profile is asked for the CRS of the response'
+        def crs = profile.getResponseCrs(apiData, COLLECTION_ID)
+
+        then: 'the default CRS of the API is not changed'
+        crs.isEmpty()
+    }
+
+    def 'no response CRS for an unknown collection'() {
+
+        given: 'a collection that is not part of the API'
+        def apiData = Stub(OgcApiDataV2)
+        apiData.getCollectionData(COLLECTION_ID) >> Optional.empty()
+        def profile = new ProfileCrsOriginal(Stub(ExtensionRegistry), Stub(FeaturesCoreProviders))
+
+        when: 'the profile is asked for the CRS of the response'
+        def crs = profile.getResponseCrs(apiData, COLLECTION_ID)
+
+        then: 'the default CRS of the API is not changed'
+        crs.isEmpty()
+    }
+}

--- a/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/SearchQueriesHandlerImpl.java
+++ b/ogcapi-draft/ogcapi-features-search/src/main/java/de/ii/ogcapi/features/search/app/SearchQueriesHandlerImpl.java
@@ -17,6 +17,7 @@ import de.ii.ogcapi.features.core.domain.FeatureQueryScope;
 import de.ii.ogcapi.features.core.domain.FeaturesCoreConfiguration;
 import de.ii.ogcapi.features.core.domain.FeaturesCoreProviders;
 import de.ii.ogcapi.features.core.domain.ImmutableFeatureTransformationContextGeneric;
+import de.ii.ogcapi.features.core.domain.ProfileResponseCrs;
 import de.ii.ogcapi.features.search.domain.FilterOperator;
 import de.ii.ogcapi.features.search.domain.ImmutableParameter;
 import de.ii.ogcapi.features.search.domain.ImmutableParameters;
@@ -459,10 +460,15 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
   }
 
   // Static counterpart of the HTML check in executeQuery(): HTML is only available for queries
-  // with paging that use the default CRS. A parameterized CRS may resolve to a non-default CRS
-  // at execution time, so HTML is not offered for such queries.
-  static boolean offersHtml(StoredQueryExpression query, EpsgCrs defaultCrs) {
+  // with paging whose positions are in the default CRS. A parameterized CRS or profile may
+  // resolve to a non-default CRS at execution time, so HTML is not offered for such queries.
+  // `crsProfileIds` are the ids of the profiles that select the CRS of the response.
+  static boolean offersHtml(
+      StoredQueryExpression query, EpsgCrs defaultCrs, Set<String> crsProfileIds) {
     if (!query.getSupportPaging().orElse(false)) {
+      return false;
+    }
+    if (selectsCrs(query, crsProfileIds)) {
       return false;
     }
     if (query.getCrs().isEmpty()) {
@@ -478,6 +484,32 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
         .orElse(false);
   }
 
+  private static boolean selectsCrs(StoredQueryExpression query, Set<String> crsProfileIds) {
+    if (query.getProfiles().isEmpty() || crsProfileIds.isEmpty()) {
+      return false;
+    }
+    Optional<List<StringOrParameter>> profiles = query.getProfiles().get().getValue();
+    if (profiles.isEmpty()) {
+      // the whole list is a parameter, so its values are only known at execution time
+      return true;
+    }
+    return profiles.get().stream()
+        .anyMatch(
+            profile ->
+                profile
+                    .getValue()
+                    .map(crsProfileIds::contains)
+                    // a parameterized entry may resolve to such a profile
+                    .orElse(true));
+  }
+
+  private Set<String> crsProfileIds() {
+    return extensionRegistry.getExtensionsForType(Profile.class).stream()
+        .filter(ProfileResponseCrs.class::isInstance)
+        .map(Profile::getId)
+        .collect(Collectors.toUnmodifiableSet());
+  }
+
   private Response getStoredQueries(
       QueryInputStoredQueries queryInput, ApiRequestContext requestContext) {
     ImmutableStoredQueries.Builder builder = new ImmutableStoredQueries.Builder();
@@ -488,12 +520,13 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
             .getExtension(FeaturesCoreConfiguration.class)
             .map(FeaturesCoreConfiguration::getDefaultEpsgCrs)
             .orElse(OgcCrs.CRS84);
+    Set<String> crsProfileIds = crsProfileIds();
     repository
         .getAll(apiData)
         .forEach(
             q -> {
               String queryId = q.getId();
-              boolean offersHtml = offersHtml(q, defaultCrs);
+              boolean offersHtml = offersHtml(q, defaultCrs, crsProfileIds);
               builder.addQueries(
                   new ImmutableStoredQuery.Builder()
                       .id(queryId)
@@ -653,7 +686,31 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
     }
 
     QueryExpression queryExpression = queryInput.getQuery();
-    EpsgCrs crs =
+
+    List<String> collectionIds =
+        queryExpression.getCollections().size() == 1
+            ? ImmutableList.of(queryExpression.getCollections().get(0))
+            : queryExpression.getQueries().stream()
+                .filter(q -> !q.getResultSetOnly())
+                .map(q -> q.getCollections().get(0))
+                .toList();
+
+    FeatureFormatExtension outputFormat =
+        requestContext
+            .getApi()
+            .getOutputFormat(
+                FeatureFormatExtension.class, requestContext.getMediaType(), Optional.empty())
+            .orElseThrow(
+                () ->
+                    new NotAcceptableException(
+                        MessageFormat.format(
+                            "The requested media type ''{0}'' is not supported for this resource.",
+                            requestContext.getMediaType())));
+
+    List<Profile> profiles =
+        negotiateQueryProfiles(requestContext, queryExpression, collectionIds, outputFormat);
+
+    Optional<EpsgCrs> requestedCrs =
         queryExpression
             .getCrs()
             .map(EpsgCrs::fromString)
@@ -668,10 +725,15 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
                                         .from(hCrs)
                                         .verticalCode(EpsgCrs.fromString(vCrsUri).getCode())
                                         .build())
-                        .orElse(hCrs))
-            .orElse(queryInput.getDefaultCrs());
+                        .orElse(hCrs));
 
-    boolean isDefaultCrs = crs.equals(queryInput.getDefaultCrs());
+    // a profile may select the CRS of the response, but only as a fallback for the CRS of the
+    // query expression (a query has no "crs" parameter)
+    Optional<EpsgCrs> responseCrs =
+        requestedCrs.or(
+            () -> crsFromProfile(profiles, requestContext.getApi().getData(), collectionIds));
+
+    boolean isDefaultCrs = responseCrs.map(queryInput.getDefaultCrs()::equals).orElse(true);
     boolean supportsPaging = queryExpression.getSupportPaging().orElse(false);
     // the embedded map in the HTML representation only supports the default CRS and an unpaged
     // response may be too large for a browser to render
@@ -681,19 +743,14 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
           MessageFormat.format(
               isDefaultCrs
                   ? "The media type ''{0}'' is not supported for queries with paging disabled."
-                  : "The media type ''{0}'' is not supported for queries that request a CRS other than the default CRS.",
+                  : "The media type ''{0}'' is not supported for queries whose positions are not in the default CRS.",
               requestContext.getMediaType().type()));
     }
 
+    EpsgCrs crs = responseCrs.orElse(queryInput.getDefaultCrs());
+
     MultiFeatureQuery query = getMultiFeatureQuery(requestContext.getApi(), queryExpression, crs);
 
-    List<String> collectionIds =
-        queryExpression.getCollections().size() == 1
-            ? ImmutableList.of(queryExpression.getCollections().get(0))
-            : queryExpression.getQueries().stream()
-                .filter(q -> !q.getResultSetOnly())
-                .map(q -> q.getCollections().get(0))
-                .toList();
     EpsgCrs targetCrs = query.getCrs().orElse(queryInput.getDefaultCrs());
     List<ApiMediaType> alternateMediaTypes =
         htmlSupported
@@ -714,17 +771,6 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
                     i18n,
                     requestContext.getLanguage())
             : ImmutableList.of();
-    FeatureFormatExtension outputFormat =
-        requestContext
-            .getApi()
-            .getOutputFormat(
-                FeatureFormatExtension.class, requestContext.getMediaType(), Optional.empty())
-            .orElseThrow(
-                () ->
-                    new NotAcceptableException(
-                        MessageFormat.format(
-                            "The requested media type ''{0}'' is not supported for this resource.",
-                            requestContext.getMediaType())));
 
     Tuple<StreamingOutput, CollectionMetadata> streamingOutputAndMetadata =
         getStreamingOutput(
@@ -735,6 +781,7 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
             collectionIds,
             featureProvider,
             outputFormat,
+            profiles,
             queryInput.getDefaultCrs(),
             targetCrs,
             queryInput.includeBodyLinks() ? links : List.of(),
@@ -761,6 +808,73 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
             i18n.getLanguages())
         .entity(streamingOutput)
         .build();
+  }
+
+  private List<Profile> negotiateQueryProfiles(
+      ApiRequestContext requestContext,
+      QueryExpression queryExpression,
+      List<String> collectionIds,
+      FeatureFormatExtension outputFormat) {
+    OgcApiDataV2 apiData = requestContext.getApi().getData();
+    List<Profile> requestedProfiles =
+        extensionRegistry.getExtensionsForType(Profile.class).stream()
+            .filter(profile -> queryExpression.getProfiles().contains(profile.getId()))
+            .toList();
+    FeaturesCoreConfiguration coreConfiguration =
+        apiData
+            .getExtension(FeaturesCoreConfiguration.class)
+            .filter(ExtensionConfiguration::isEnabled)
+            .filter(
+                cfg ->
+                    cfg.getItemType().orElse(FeaturesCoreConfiguration.ItemType.feature)
+                        != FeaturesCoreConfiguration.ItemType.unknown)
+            .orElseThrow(() -> new NotFoundException("Features are not supported for this API."));
+    List<Profile> defaultProfilesFeaturesCore =
+        extensionRegistry.getExtensionsForType(Profile.class).stream()
+            .filter(
+                profile ->
+                    coreConfiguration.getDefaultProfiles().containsKey(profile.getProfileSet())
+                        && profile
+                            .getId()
+                            .equals(
+                                coreConfiguration
+                                    .getDefaultProfiles()
+                                    .get(profile.getProfileSet())))
+            .toList();
+
+    return collectionIds.stream()
+        .flatMap(
+            collectionId ->
+                extensionRegistry.getExtensionsForType(ProfileSet.class).stream()
+                    .filter(p -> p.isEnabledForApi(apiData, collectionId))
+                    .map(
+                        profileSet ->
+                            profileSet
+                                .negotiateProfile(
+                                    requestedProfiles,
+                                    defaultProfilesFeaturesCore,
+                                    outputFormat,
+                                    ResourceType.FEATURE,
+                                    apiData,
+                                    Optional.of(collectionId))
+                                .orElse(null))
+                    .filter(Objects::nonNull))
+        .distinct()
+        .toList();
+  }
+
+  private static Optional<EpsgCrs> crsFromProfile(
+      List<Profile> profiles, OgcApiDataV2 apiData, List<String> collectionIds) {
+    return profiles.stream()
+        .filter(ProfileResponseCrs.class::isInstance)
+        .flatMap(
+            profile ->
+                collectionIds.stream()
+                    .flatMap(
+                        collectionId ->
+                            ((ProfileResponseCrs) profile)
+                                .getResponseCrs(apiData, collectionId).stream()))
+        .findFirst();
   }
 
   private MultiFeatureQuery getMultiFeatureQuery(
@@ -1052,6 +1166,7 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
       List<String> collectionIds,
       FeatureProvider featureProvider,
       FeatureFormatExtension outputFormat,
+      List<Profile> profiles,
       EpsgCrs defaultCrs,
       EpsgCrs targetCrs,
       List<Link> links,
@@ -1063,56 +1178,6 @@ public class SearchQueriesHandlerImpl extends AbstractVolatileComposed
       sourceCrs = featureProvider.crs().get().getNativeCrs();
       crsTransformer = crsTransformerFactory.getTransformer(sourceCrs, targetCrs);
     }
-
-    // negotiate profiles
-    List<Profile> requestedProfiles =
-        extensionRegistry.getExtensionsForType(Profile.class).stream()
-            .filter(profile -> queryExpression.getProfiles().contains(profile.getId()))
-            .toList();
-    FeaturesCoreConfiguration coreConfiguration =
-        requestContext
-            .getApi()
-            .getData()
-            .getExtension(FeaturesCoreConfiguration.class)
-            .filter(ExtensionConfiguration::isEnabled)
-            .filter(
-                cfg ->
-                    cfg.getItemType().orElse(FeaturesCoreConfiguration.ItemType.feature)
-                        != FeaturesCoreConfiguration.ItemType.unknown)
-            .orElseThrow(() -> new NotFoundException("Features are not supported for this API."));
-    List<Profile> defaultProfilesFeaturesCore =
-        extensionRegistry.getExtensionsForType(Profile.class).stream()
-            .filter(
-                profile ->
-                    coreConfiguration.getDefaultProfiles().containsKey(profile.getProfileSet())
-                        && profile
-                            .getId()
-                            .equals(
-                                coreConfiguration
-                                    .getDefaultProfiles()
-                                    .get(profile.getProfileSet())))
-            .toList();
-    List<Profile> profiles =
-        collectionIds.stream()
-            .flatMap(
-                collectionId ->
-                    extensionRegistry.getExtensionsForType(ProfileSet.class).stream()
-                        .filter(
-                            p -> p.isEnabledForApi(requestContext.getApi().getData(), collectionId))
-                        .map(
-                            profileSet ->
-                                profileSet
-                                    .negotiateProfile(
-                                        requestedProfiles,
-                                        defaultProfilesFeaturesCore,
-                                        outputFormat,
-                                        ResourceType.FEATURE,
-                                        api.getData(),
-                                        Optional.of(collectionId))
-                                    .orElse(null))
-                        .filter(Objects::nonNull))
-            .distinct()
-            .toList();
 
     // multiple queries may use the same feature type, all type-keyed maps need a merge function
     Map<String, Optional<FeatureSchema>> schemas =

--- a/ogcapi-draft/ogcapi-features-search/src/test/groovy/de/ii/ogcapi/features/search/app/StoredQueriesHtmlOfferSpec.groovy
+++ b/ogcapi-draft/ogcapi-features-search/src/test/groovy/de/ii/ogcapi/features/search/app/StoredQueriesHtmlOfferSpec.groovy
@@ -7,9 +7,11 @@
  */
 package de.ii.ogcapi.features.search.app
 
+import de.ii.ogcapi.features.search.domain.ImmutableParameterOrListOfStringOrParameter
 import de.ii.ogcapi.features.search.domain.ImmutableParameterValue
 import de.ii.ogcapi.features.search.domain.ImmutableStoredQueryExpression
 import de.ii.ogcapi.features.search.domain.ImmutableStringOrParameter
+import de.ii.ogcapi.features.search.domain.ParameterOrListOfStringOrParameter
 import de.ii.ogcapi.features.search.domain.StoredQueryExpression
 import de.ii.ogcapi.features.search.domain.StringOrParameter
 import de.ii.xtraplatform.crs.domain.OgcCrs
@@ -18,16 +20,32 @@ import de.ii.xtraplatform.jsonschema.domain.ImmutableJsonSchemaString
 import spock.lang.Specification
 
 // The stored queries page only offers HTML for queries that can actually be executed as HTML:
-// paging enabled and the default CRS. This locks the static check against the runtime rule in
-// SearchQueriesHandlerImpl.executeQuery (406 for HTML otherwise).
+// paging enabled and positions in the default CRS. This locks the static check against the runtime
+// rule in SearchQueriesHandlerImpl.executeQuery (406 for HTML otherwise).
 class StoredQueriesHtmlOfferSpec extends Specification {
 
     static final String CRS84_URI = 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
     static final String UTM32_URI = 'http://www.opengis.net/def/crs/EPSG/0/25832'
     static final String HEIGHT_URI = 'http://www.opengis.net/def/crs/EPSG/0/7837'
+    static final Set<String> CRS_PROFILES = ['crs-original'] as Set
 
     static StringOrParameter literal(String value) {
         return new ImmutableStringOrParameter.Builder().value(value).build()
+    }
+
+    static ParameterOrListOfStringOrParameter profileList(StringOrParameter... items) {
+        return new ImmutableParameterOrListOfStringOrParameter.Builder()
+                .value(items as List)
+                .build()
+    }
+
+    static ParameterOrListOfStringOrParameter profileParameter(String name) {
+        return new ImmutableParameterOrListOfStringOrParameter.Builder()
+                .parameter(new ImmutableParameterValue.Builder()
+                        .name(name)
+                        .schema(new ImmutableJsonSchemaRef.Builder().ref('#/parameters/' + name).build())
+                        .build())
+                .build()
     }
 
     static StringOrParameter parameter(String name) {
@@ -59,7 +77,7 @@ class StoredQueriesHtmlOfferSpec extends Specification {
         StoredQueryExpression query = builder.build()
 
         expect:
-        SearchQueriesHandlerImpl.offersHtml(query, OgcCrs.CRS84) == expected
+        SearchQueriesHandlerImpl.offersHtml(query, OgcCrs.CRS84, CRS_PROFILES) == expected
 
         where:
         label                        | paging | crs                | verticalCrs         || expected
@@ -72,5 +90,33 @@ class StoredQueriesHtmlOfferSpec extends Specification {
         'paged, composed 3D CRS'     | true   | literal(CRS84_URI) | literal(HEIGHT_URI) || false
         'vertical CRS without CRS'   | true   | null               | literal(HEIGHT_URI) || true
         'unpaged, non-default CRS'   | false  | literal(UTM32_URI) | null                || false
+    }
+
+    def 'HTML is not offered for a query with a profile that selects the CRS (#label)'() {
+        given: 'a paged stored query with profiles'
+        def builder = new ImmutableStoredQueryExpression.Builder()
+                .id('test-query')
+                .addCollections(literal('ax_test'))
+                .supportPaging(true)
+        if (profiles != null) {
+            builder.profiles(profiles)
+        }
+        if (paramName != null) {
+            builder.putParameters(paramName, new ImmutableJsonSchemaString.Builder().build())
+        }
+        StoredQueryExpression query = builder.build()
+
+        expect:
+        SearchQueriesHandlerImpl.offersHtml(query, OgcCrs.CRS84, CRS_PROFILES) == expected
+
+        where:
+        label                       | profiles                             | paramName  || expected
+        'no profiles'               | null                                 | null       || true
+        'unrelated profile'         | profileList(literal('jsonfg'))       | null       || true
+        'crs-original'              | profileList(literal('crs-original')) | null       || false
+        'crs-original among others' | profileList(literal('jsonfg'),
+                                                  literal('crs-original')) | null       || false
+        'parameterized entry'       | profileList(parameter('profile'))    | 'profile'  || false
+        'parameterized list'        | profileParameter('profiles')         | 'profiles' || false
     }
 }

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/FeaturesCoreQueriesHandlerImpl.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/app/FeaturesCoreQueriesHandlerImpl.java
@@ -20,6 +20,7 @@ import de.ii.ogcapi.features.core.domain.FeaturesCoreQueriesHandler;
 import de.ii.ogcapi.features.core.domain.FeaturesLinksGenerator;
 import de.ii.ogcapi.features.core.domain.ImmutableFeatureTransformationContextGeneric;
 import de.ii.ogcapi.features.core.domain.ProfileFeatureQuery;
+import de.ii.ogcapi.features.core.domain.ProfileResponseCrs;
 import de.ii.ogcapi.features.core.domain.PropertyLinkResolver;
 import de.ii.ogcapi.features.core.domain.SingleFeatureMissingHandler;
 import de.ii.ogcapi.foundation.domain.ApiMediaType;
@@ -30,6 +31,7 @@ import de.ii.ogcapi.foundation.domain.HeaderContentDisposition;
 import de.ii.ogcapi.foundation.domain.I18n;
 import de.ii.ogcapi.foundation.domain.Link;
 import de.ii.ogcapi.foundation.domain.OgcApi;
+import de.ii.ogcapi.foundation.domain.OgcApiDataV2;
 import de.ii.ogcapi.foundation.domain.OgcApiQueryParameter;
 import de.ii.ogcapi.foundation.domain.Profile;
 import de.ii.ogcapi.foundation.domain.ProfileExtension.ResourceType;
@@ -43,6 +45,7 @@ import de.ii.xtraplatform.base.domain.resiliency.AbstractVolatileComposed;
 import de.ii.xtraplatform.base.domain.resiliency.VolatileRegistry;
 import de.ii.xtraplatform.codelists.domain.Codelist;
 import de.ii.xtraplatform.crs.domain.BoundingBox;
+import de.ii.xtraplatform.crs.domain.CrsInfo;
 import de.ii.xtraplatform.crs.domain.CrsTransformer;
 import de.ii.xtraplatform.crs.domain.CrsTransformerFactory;
 import de.ii.xtraplatform.crs.domain.EpsgCrs;
@@ -105,8 +108,13 @@ public class FeaturesCoreQueriesHandlerImpl extends AbstractVolatileComposed
   private static final Logger LOGGER =
       LoggerFactory.getLogger(FeaturesCoreQueriesHandlerImpl.class);
 
+  // the name of the "crs" query parameter; the parameter is defined in the CRS building block,
+  // which depends on this module
+  private static final String CRS = "crs";
+
   private final I18n i18n;
   private final CrsTransformerFactory crsTransformerFactory;
+  private final CrsInfo crsInfo;
   private final Map<Query, QueryHandler<? extends QueryInput>> queryHandlers;
   private final Values<Codelist> codelistStore;
   private final ExtensionRegistry extensionRegistry;
@@ -115,12 +123,14 @@ public class FeaturesCoreQueriesHandlerImpl extends AbstractVolatileComposed
   public FeaturesCoreQueriesHandlerImpl(
       I18n i18n,
       CrsTransformerFactory crsTransformerFactory,
+      CrsInfo crsInfo,
       ValueStore valueStore,
       VolatileRegistry volatileRegistry,
       ExtensionRegistry extensionRegistry) {
     super(FeaturesCoreQueriesHandler.class.getSimpleName(), volatileRegistry, true);
     this.i18n = i18n;
     this.crsTransformerFactory = crsTransformerFactory;
+    this.crsInfo = crsInfo;
     this.codelistStore = valueStore.forType(Codelist.class);
     this.extensionRegistry = extensionRegistry;
 
@@ -132,6 +142,7 @@ public class FeaturesCoreQueriesHandlerImpl extends AbstractVolatileComposed
     onVolatileStart();
 
     addSubcomponent(crsTransformerFactory);
+    addSubcomponent(crsInfo);
 
     onVolatileStarted();
   }
@@ -139,6 +150,37 @@ public class FeaturesCoreQueriesHandlerImpl extends AbstractVolatileComposed
   @Override
   public Map<Query, QueryHandler<? extends QueryInput>> getQueryHandlers() {
     return queryHandlers;
+  }
+
+  private static Optional<EpsgCrs> crsFromProfile(
+      List<Profile> profiles, OgcApiDataV2 apiData, String collectionId) {
+    return profiles.stream()
+        .filter(ProfileResponseCrs.class::isInstance)
+        .flatMap(
+            profile ->
+                ((ProfileResponseCrs) profile).getResponseCrs(apiData, collectionId).stream())
+        .findFirst();
+  }
+
+  private FeatureQuery withCrs(
+      FeatureQuery query, EpsgCrs crs, OgcApiDataV2 apiData, String collectionId) {
+    if (query.getCrs().filter(crs::equals).isPresent()) {
+      return query;
+    }
+
+    ImmutableFeatureQuery.Builder builder = ImmutableFeatureQuery.builder().from(query).crs(crs);
+
+    // the coordinate precision depends on the units of the CRS
+    Map<String, Integer> coordinatePrecision =
+        apiData
+            .getExtension(FeaturesCoreConfiguration.class, collectionId)
+            .map(FeaturesCoreConfiguration::getCoordinatePrecision)
+            .orElse(Map.of());
+    if (!coordinatePrecision.isEmpty()) {
+      builder.geometryPrecision(crsInfo.getPrecisionList(crs, coordinatePrecision));
+    }
+
+    return builder.build();
   }
 
   private Response getItemsResponse(
@@ -260,15 +302,6 @@ public class FeaturesCoreQueriesHandlerImpl extends AbstractVolatileComposed
     QueriesHandler.ensureCollectionIdExists(api.getData(), collectionId);
     QueriesHandler.ensureFeatureProviderSupportsQueries(featureProvider);
 
-    Optional<CrsTransformer> crsTransformer = Optional.empty();
-
-    EpsgCrs sourceCrs = null;
-    EpsgCrs targetCrs = query.getCrs().orElse(defaultCrs);
-    if (featureProvider.crs().isAvailable()) {
-      sourceCrs = featureProvider.crs().get().getNativeCrs();
-      crsTransformer = crsTransformerFactory.getTransformer(sourceCrs, targetCrs);
-    }
-
     List<ApiMediaType> alternateMediaTypes = requestContext.getAlternateMediaTypes();
 
     List<ProfileSet> allProfileSets = extensionRegistry.getExtensionsForType(ProfileSet.class);
@@ -282,6 +315,26 @@ public class FeaturesCoreQueriesHandlerImpl extends AbstractVolatileComposed
             Optional.of(collectionId),
             queryInput.getProfiles(),
             queryInput.getDefaultProfilesResource());
+
+    // A profile may select the CRS of the response, but only as a fallback for the default CRS.
+    // HTML is excluded for the same reason the endpoint already drops the "crs" parameter for it:
+    // the representation is always in the default CRS.
+    if (!requestContext.getQueryParameterSet().getValues().containsKey(CRS)
+        && !MediaType.TEXT_HTML_TYPE.equals(outputFormat.getMediaType().type())) {
+      Optional<EpsgCrs> profileCrs = crsFromProfile(profiles, api.getData(), collectionId);
+      if (profileCrs.isPresent()) {
+        query = withCrs(query, profileCrs.get(), api.getData(), collectionId);
+      }
+    }
+
+    Optional<CrsTransformer> crsTransformer = Optional.empty();
+
+    EpsgCrs sourceCrs = null;
+    EpsgCrs targetCrs = query.getCrs().orElse(defaultCrs);
+    if (featureProvider.crs().isAvailable()) {
+      sourceCrs = featureProvider.crs().get().getNativeCrs();
+      crsTransformer = crsTransformerFactory.getTransformer(sourceCrs, targetCrs);
+    }
 
     Map<ApiMediaType, List<Profile>> alternateProfiles =
         getAlternateProfiles(

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/ProfileResponseCrs.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/ProfileResponseCrs.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.features.core.domain;
+
+import de.ii.ogcapi.foundation.domain.OgcApiDataV2;
+import de.ii.xtraplatform.crs.domain.EpsgCrs;
+import jakarta.validation.constraints.NotNull;
+import java.util.Optional;
+
+/**
+ * A profile that selects the coordinate reference system of the geometries in the response. The CRS
+ * is a fallback for the default CRS of the API: it is only used if the request does not include a
+ * {@code crs} parameter. It is ignored for HTML, where the {@code crs} parameter is ignored as
+ * well.
+ */
+public interface ProfileResponseCrs {
+
+  /**
+   * The CRS of the geometries in the response, or an empty value if the profile does not change the
+   * CRS for the collection.
+   */
+  Optional<EpsgCrs> getResponseCrs(@NotNull OgcApiDataV2 apiData, @NotNull String collectionId);
+}

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/GmlWriterPositionVariants.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/GmlWriterPositionVariants.java
@@ -53,9 +53,9 @@ public class GmlWriterPositionVariants implements GmlWriter {
    * referenced here by its literal value — the encoder must not depend on the profile module). With
    * the profile active, positions are written as recorded: from whichever variant property is set,
    * with the stored verbatim srsName. Without it, the variant and helper properties are only
-   * suppressed — the base geometry property (transformed to the requested CRS upstream) passes
-   * through to the normal geometry writer, and a feature without a base geometry (a 1D position)
-   * has no position element.
+   * suppressed — the base geometry property (transformed to the CRS of the response upstream)
+   * passes through to the normal geometry writer, and a feature without a base geometry (a 1D
+   * position) has no position element.
    */
   static final String PROFILE_CRS_ORIGINAL = "crs-original";
 
@@ -158,7 +158,7 @@ public class GmlWriterPositionVariants implements GmlWriter {
             }
           }
           // without the profile the variant is suppressed; the base property carries the derived
-          // native position, transformed to the requested CRS upstream
+          // native position, transformed to the CRS of the response upstream
           return;
         }
         if (crsOriginal && path.equals(entry.getKey())) {
@@ -171,7 +171,8 @@ public class GmlWriterPositionVariants implements GmlWriter {
             writeVariantPosition(context, elementName(entry.getKey()));
             return;
           }
-          // native row — the base property carries the original position
+          // native row — the base property carries the position in the CRS of the response, which
+          // with the profile is the CRS of the provider unless the request asks for another CRS
           break;
         }
       }


### PR DESCRIPTION
### Pull request checklist

-   [x] Added/updated unit tests
-   [x] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

The crs-original profile only replaced the positions of a geometry property with a crsVariants declaration; every other position was returned in the requested or in the default CRS of the API, which was not intuitive. The profile now also selects the CRS of the response, so that a position without a variant is returned in the CRS in which the feature provider stores it.

The CRS is a fallback for the default CRS of the API: a crs parameter in the request, or a crs in a query expression, takes precedence. In the HTML representation the profile is ignored, as is the crs parameter.

- ogcapi-features-core: new ProfileResponseCrs, applied in FeaturesCoreQueriesHandlerImpl before the CRS transformer is created - the profiles are negotiated first and the coordinate precision is recomputed for the selected CRS
- ogcapi-profile-crs: ProfileCrsOriginal returns the CRS of the feature provider; the profile set is no longer restricted to collections with a crsVariants declaration, which would make the positions of a query over multiple collections depend on the collections in the query
- ogcapi-features-search: the profiles are negotiated before the CRS of the query is determined; a profile that selects the CRS rules out HTML, both for a request (406) and for the formats offered for a stored query
- documentation, and specs for the CRS of the response and for the HTML rule
