### PR TITLE
transactions: fix oversized response for Prefer return=none

### DIFF
--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/CommandHandlerTransactionsImpl.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/CommandHandlerTransactionsImpl.java
@@ -236,7 +236,11 @@ public class CommandHandlerTransactionsImpl extends AbstractVolatileComposed
     ArrayNode deleteResults = body.putArray("deleteResults");
     ArrayNode exceptions = MAPPER.createArrayNode();
 
-    boolean wantDetails = ret != HeaderPrefer.Return.MINIMAL;
+    // Only `return=representation` asks for the per-feature URIs. `return=none` reaches this
+    // point when the response cannot be empty after all — the transaction failed, or it
+    // succeeded with warnings — and a client that asked for nothing should then get the
+    // smallest body that still carries the outcome, not the largest one.
+    boolean wantDetails = ret == HeaderPrefer.Return.REPRESENTATION;
 
     for (ActionResult r : result.getActionResults()) {
       addExceptionsFor(r, exceptions);
@@ -250,7 +254,7 @@ public class CommandHandlerTransactionsImpl extends AbstractVolatileComposed
       }
     }
 
-    if (ret == HeaderPrefer.Return.MINIMAL) {
+    if (!wantDetails) {
       body.remove("insertResults");
       body.remove("replaceResults");
       body.remove("updateResults");

--- a/ogcapi-draft/ogcapi-transactions/src/test/groovy/de/ii/ogcapi/transactions/app/CommandHandlerTransactionsSpec.groovy
+++ b/ogcapi-draft/ogcapi-transactions/src/test/groovy/de/ii/ogcapi/transactions/app/CommandHandlerTransactionsSpec.groovy
@@ -184,6 +184,59 @@ class CommandHandlerTransactionsSpec extends Specification {
         ]
     }
 
+    def "return=none falls back to the minimal body when warnings force a response"() {
+        given:
+        RecordingParser parser = new RecordingParser(actions: [action()])
+        FixedResultExecutor executor = new FixedResultExecutor(result: successWithFeature())
+        CommandHandlerTransactionsImpl handler = new CommandHandlerTransactionsImpl(executor, volatileRegistry)
+
+        when:
+        def response = handler.processTransaction(
+                queryInput(parser, '{"transaction":[]}', config(0), HeaderPrefer.Handling.LENIENT,
+                        HeaderPrefer.Return.NONE),
+                requestContext())
+        def json = (Map) new JsonSlurper().parseText((String) response.entity)
+
+        then: "the outcome is reported, but not one URI per feature"
+        response.status == 200
+        !json.containsKey('deleteResults')
+        !json.containsKey('insertResults')
+        json.get('summary') != null
+        ((List) json.get('warnings')) == ['pre-commit check: 2 orphaned rows']
+    }
+
+    def "return=representation still carries the per-feature URIs"() {
+        given:
+        RecordingParser parser = new RecordingParser(actions: [action()])
+        FixedResultExecutor executor = new FixedResultExecutor(result: successWithFeature())
+        CommandHandlerTransactionsImpl handler = new CommandHandlerTransactionsImpl(executor, volatileRegistry)
+
+        when:
+        def response = handler.processTransaction(
+                queryInput(parser, '{"transaction":[]}', config(0), HeaderPrefer.Handling.LENIENT,
+                        HeaderPrefer.Return.REPRESENTATION),
+                requestContext())
+        def json = (Map) new JsonSlurper().parseText((String) response.entity)
+
+        then:
+        response.status == 200
+        ((List) json.get('deleteResults')).size() == 1
+    }
+
+    private static ExecutionResult successWithFeature() {
+        return new ImmutableExecutionResult.Builder()
+                .semantic(TxSemantic.ATOMIC)
+                .actionResults([new ImmutableActionResult.Builder()
+                                        .type(TxActionType.DELETE)
+                                        .collectionId('c')
+                                        .actionId('a1')
+                                        .status(ActionStatus.SUCCESS)
+                                        .featureIds(['f1'])
+                                        .build()])
+                .warnings(['pre-commit check: 2 orphaned rows'])
+                .build()
+    }
+
     private static de.ii.ogcapi.transactions.domain.ActionResult actionResult(
             String actionId, ActionStatus status, String error) {
         def builder = new ImmutableActionResult.Builder()
@@ -202,6 +255,15 @@ class CommandHandlerTransactionsSpec extends Specification {
             String body,
             TransactionsConfiguration config,
             HeaderPrefer.Handling handling) {
+        return queryInput(parser, body, config, handling, HeaderPrefer.Return.REPRESENTATION)
+    }
+
+    private static CommandHandlerTransactions.QueryInputTransaction queryInput(
+            RecordingParser parser,
+            String body,
+            TransactionsConfiguration config,
+            HeaderPrefer.Handling handling,
+            HeaderPrefer.Return returnPreference) {
         return ImmutableQueryInputTransaction.builder()
                 .parser(parser)
                 .requestBody(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)))
@@ -209,7 +271,7 @@ class CommandHandlerTransactionsSpec extends Specification {
                 .config(config)
                 .requestCrs(OgcCrs.CRS84)
                 .handling(handling)
-                .returnPreference(HeaderPrefer.Return.REPRESENTATION)
+                .returnPreference(returnPreference)
                 .build()
     }
 


### PR DESCRIPTION
### Pull request checklist

-   [x] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

A client asking for `return=none` gets 204 No Content only when the transaction succeeded and produced no warnings. In every other case the response fell through to the full representation, so a request that asked for nothing received the largest body available: one URI per written feature, which on a batch transaction can be many entries.

`return=none` now renders the same minimal body as `return=minimal` when a response is unavoidable: semantic, summary, exceptions and warnings, without the per-feature URI arrays.
