### PR TITLE
fix: sortby accepted any property when no sortables are configured

### DIFF
--- a/ogcapi-draft/ogcapi-sorting/build.gradle
+++ b/ogcapi-draft/ogcapi-sorting/build.gradle
@@ -15,4 +15,8 @@ dependencies {
     provided 'de.interactive_instruments:ogcapi-collections-queryables'
     provided 'de.interactive_instruments:ogcapi-common'
     provided 'de.interactive_instruments:ogcapi-features-core'
+
+    testProvided 'de.interactive_instruments:xtraplatform-cql'
+    testProvided 'de.interactive_instruments:xtraplatform-crs'
+    testProvided 'de.interactive_instruments:xtraplatform-geometries'
 }

--- a/ogcapi-draft/ogcapi-sorting/src/main/java/de/ii/ogcapi/sorting/app/QueryParameterSortbyFeatures.java
+++ b/ogcapi-draft/ogcapi-sorting/src/main/java/de/ii/ogcapi/sorting/app/QueryParameterSortbyFeatures.java
@@ -25,7 +25,6 @@ import de.ii.ogcapi.foundation.domain.SchemaValidator;
 import de.ii.ogcapi.foundation.domain.SpecificationMaturity;
 import de.ii.ogcapi.foundation.domain.TypedQueryParameter;
 import de.ii.ogcapi.sorting.domain.SortingConfiguration;
-import de.ii.xtraplatform.features.domain.FeatureSchema;
 import de.ii.xtraplatform.features.domain.ImmutableFeatureQuery.Builder;
 import de.ii.xtraplatform.features.domain.SortKey;
 import de.ii.xtraplatform.features.domain.SortKey.Direction;
@@ -48,11 +47,15 @@ import java.util.stream.Collectors;
  * @endpoints Features
  * @langEn If the parameter is specified, the features are returned sorted according to the
  *     attributes specified in a comma-separated list. The attribute name can be preceded by `+`
- *     (ascending, the default behavior) or `-` (descending). Example: `sortby=type,-name`.
+ *     (ascending, the default behavior) or `-` (descending). Example: `sortby=type,-name`. Only the
+ *     sortable properties of the collection are accepted; the parameter is not available for
+ *     collections without sortable properties.
  * @langDe Ist der Parameter angegeben, werden die Features sortiert zurückgegeben. Sortiert wird
  *     nach den in einer kommaseparierten Liste angegebenen Attributen. Dem Attributnamen kann ein
  *     `+` (aufsteigend, das Standardverhalten) oder ein `-` (absteigend) vorangestellt werden.
- *     Beispiel: `sortby=type,-name`.
+ *     Beispiel: `sortby=type,-name`. Es werden nur die sortierbaren Eigenschaften der Collection
+ *     akzeptiert; für Collections ohne sortierbare Eigenschaften steht der Parameter nicht zur
+ *     Verfügung.
  */
 @Singleton
 @AutoBind
@@ -161,6 +164,23 @@ public class QueryParameterSortbyFeatures extends OgcApiQueryParameterBase
   }
 
   @Override
+  public boolean isEnabledForApi(OgcApiDataV2 apiData, String collectionId) {
+    if (!apiData.isCollectionEnabled(collectionId)) {
+      return false;
+    }
+    FeatureTypeConfigurationOgcApi collectionData = apiData.getCollections().get(collectionId);
+    if (!isExtensionEnabled(collectionData, SortingConfiguration.class)) {
+      return false;
+    }
+    boolean hasDefaultSortby =
+        collectionData
+            .getExtension(SortingConfiguration.class)
+            .map(cfg -> !cfg.getDefaultSortby().isEmpty())
+            .orElse(false);
+    return hasDefaultSortby || !getSortables(apiData, collectionData).isEmpty();
+  }
+
+  @Override
   public Schema<?> getSchema(OgcApiDataV2 apiData) {
     int apiHashCode = apiData.hashCode();
     if (!schemaMap.containsKey(apiHashCode)) {
@@ -181,31 +201,41 @@ public class QueryParameterSortbyFeatures extends OgcApiQueryParameterBase
     if (!schemaMap.get(apiHashCode).containsKey(collectionId)) {
       FeatureTypeConfigurationOgcApi collectionData =
           Objects.requireNonNull(apiData.getCollections().get(collectionId));
-      FeatureSchema featureSchema =
-          providers.getFeatureSchema(apiData, collectionData).orElseThrow();
-      List<String> sortables =
-          collectionData
-              .getExtension(SortingConfiguration.class)
-              .map(
-                  cfg ->
-                      cfg
-                          .getSortables(apiData, collectionData, featureSchema, providers)
-                          .keySet()
-                          .stream()
-                          .collect(Collectors.toUnmodifiableList()))
-              .orElse(ImmutableList.of());
+      List<String> sortables = getSortables(apiData, collectionData);
       List<String> enums =
           sortables.stream()
               .map(p -> ImmutableList.of(p, "+" + p, "-" + p))
               .flatMap(Collection::stream)
               .collect(Collectors.toUnmodifiableList());
       StringSchema sortableSchema = new StringSchema();
-      if (!enums.isEmpty()) {
+      ArraySchema arraySchema = new ArraySchema().items(sortableSchema);
+      if (enums.isEmpty()) {
+        // no sortable properties, no sort key is valid
+        arraySchema.maxItems(0);
+      } else {
         sortableSchema._enum(enums);
       }
-      schemaMap.get(apiHashCode).put(collectionId, new ArraySchema().items(sortableSchema));
+      schemaMap.get(apiHashCode).put(collectionId, arraySchema);
     }
     return schemaMap.get(apiHashCode).get(collectionId);
+  }
+
+  private List<String> getSortables(
+      OgcApiDataV2 apiData, FeatureTypeConfigurationOgcApi collectionData) {
+    return collectionData
+        .getExtension(SortingConfiguration.class)
+        .flatMap(
+            cfg ->
+                providers
+                    .getFeatureSchema(apiData, collectionData)
+                    .map(
+                        featureSchema ->
+                            cfg
+                                .getSortables(apiData, collectionData, featureSchema, providers)
+                                .keySet()
+                                .stream()
+                                .collect(Collectors.toUnmodifiableList())))
+        .orElse(ImmutableList.of());
   }
 
   @Override

--- a/ogcapi-draft/ogcapi-sorting/src/test/groovy/de/ii/ogcapi/sorting/app/QueryParameterSortbyFeaturesSpec.groovy
+++ b/ogcapi-draft/ogcapi-sorting/src/test/groovy/de/ii/ogcapi/sorting/app/QueryParameterSortbyFeaturesSpec.groovy
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.sorting.app
+
+import de.ii.ogcapi.collections.queryables.domain.QueryablesConfiguration.PathSeparator
+import de.ii.ogcapi.features.core.domain.FeaturesCoreProviders
+import de.ii.ogcapi.foundation.domain.ImmutableFeatureTypeConfigurationOgcApi
+import de.ii.ogcapi.foundation.domain.ImmutableOgcApiDataV2
+import de.ii.ogcapi.foundation.domain.OgcApiDataV2
+import de.ii.ogcapi.foundation.infra.json.SchemaValidatorImpl
+import de.ii.ogcapi.sorting.domain.ImmutableSortingConfiguration
+import de.ii.ogcapi.sorting.domain.SortingConfiguration
+import de.ii.xtraplatform.features.domain.FeatureQueries
+import de.ii.xtraplatform.features.domain.FeatureSchema
+import de.ii.xtraplatform.features.domain.ImmutableFeatureSchema
+import de.ii.xtraplatform.features.domain.SchemaBase
+import de.ii.xtraplatform.features.domain.transform.OnlySortables
+import io.swagger.v3.oas.models.media.ArraySchema
+import spock.lang.Specification
+
+import java.util.function.Predicate
+
+class QueryParameterSortbyFeaturesSpec extends Specification {
+
+    static final String COLLECTION_ID = 'test'
+
+    def 'the parameter is not available for a collection without sortable properties'() {
+        given: 'sorting is enabled, but no property is included as a sortable'
+        def parameter = createParameter()
+        def apiData = createApiData(sortingConfiguration([], []))
+
+        expect: 'the parameter is disabled for the collection'
+        !parameter.isEnabledForApi(apiData, COLLECTION_ID)
+    }
+
+    def 'the parameter is not available if all sortable properties are excluded'() {
+        given: 'all properties are included as sortables, but all of them are also excluded'
+        def parameter = createParameter()
+        def apiData = createApiData(sortingConfiguration(['*'], ['name', 'date']))
+
+        expect: 'the parameter is disabled for the collection'
+        !parameter.isEnabledForApi(apiData, COLLECTION_ID)
+    }
+
+    def 'only the sortable properties are accepted as sort keys'() {
+        given: 'sorting is enabled with a single sortable property'
+        def parameter = createParameter()
+        def apiData = createApiData(sortingConfiguration(['name'], []))
+
+        expect: 'the parameter is enabled for the collection'
+        parameter.isEnabledForApi(apiData, COLLECTION_ID)
+
+        and: 'the schema only allows the sortable property'
+        ((ArraySchema) parameter.getSchema(apiData, COLLECTION_ID)).getItems().getEnum() == ['name', '+name', '-name']
+
+        and: 'sort keys for the sortable property are valid'
+        parameter.validate(apiData, Optional.of(COLLECTION_ID), ['-name']).isEmpty()
+
+        and: 'a sort key for another property of the feature type is rejected'
+        parameter.validate(apiData, Optional.of(COLLECTION_ID), ['date']).isPresent()
+    }
+
+    def 'a default sort order without sortable properties rejects all sort keys'() {
+        given: 'sorting is enabled with a default sort order, but without sortables'
+        def parameter = createParameter()
+        def apiData = createApiData(sortingConfiguration([], [], ['name']))
+
+        expect: 'the parameter is enabled for the collection'
+        parameter.isEnabledForApi(apiData, COLLECTION_ID)
+
+        and: 'no sort key is valid'
+        ((ArraySchema) parameter.getSchema(apiData, COLLECTION_ID)).getMaxItems() == 0
+        parameter.validate(apiData, Optional.of(COLLECTION_ID), ['name']).isPresent()
+
+        and: 'the default sort order is applied when the parameter is absent'
+        def sortKeys = parameter.parse((String) null, [:], null, Optional.of(apiData.getCollections().get(COLLECTION_ID)))
+        sortKeys*.getField() == ['name']
+    }
+
+    QueryParameterSortbyFeatures createParameter() {
+        FeatureQueries featureQueries = Stub()
+        featureQueries.getSortablesSchema(_ as FeatureSchema, _ as List, _ as List, _ as String) >> {
+            FeatureSchema schema, List<String> included, List<String> excluded, String pathSeparator ->
+                schema.accept(new OnlySortables(included, excluded, pathSeparator, { path -> false } as Predicate))
+        }
+        FeaturesCoreProviders providers = Stub()
+        providers.getFeatureSchema(_, _) >> Optional.of(featureSchema())
+        providers.getFeatureProviderOrThrow(_, _, _) >> featureQueries
+        return new QueryParameterSortbyFeatures(new SchemaValidatorImpl(), providers)
+    }
+
+    static FeatureSchema featureSchema() {
+        return new ImmutableFeatureSchema.Builder()
+                .name(COLLECTION_ID)
+                .type(SchemaBase.Type.OBJECT)
+                .sourcePath('/test')
+                .putProperties2('name', new ImmutableFeatureSchema.Builder()
+                        .type(SchemaBase.Type.STRING))
+                .putProperties2('date', new ImmutableFeatureSchema.Builder()
+                        .type(SchemaBase.Type.DATE))
+                .build()
+    }
+
+    static OgcApiDataV2 createApiData(SortingConfiguration sortingConfiguration) {
+        return new ImmutableOgcApiDataV2.Builder()
+                .id('api')
+                .serviceType('OGC_API')
+                .putCollections(COLLECTION_ID, new ImmutableFeatureTypeConfigurationOgcApi.Builder()
+                        .id(COLLECTION_ID)
+                        .label(COLLECTION_ID)
+                        .enabled(true)
+                        .addExtensions(sortingConfiguration)
+                        .build())
+                .build()
+    }
+
+    static SortingConfiguration sortingConfiguration(List<String> included, List<String> excluded, List<String> defaultSortby = []) {
+        return new ImmutableSortingConfiguration.Builder()
+                .enabled(true)
+                .pathSeparator(PathSeparator.DOT)
+                .included(included)
+                .excluded(excluded)
+                .defaultSortby(defaultSortby)
+                .build()
+    }
+}


### PR DESCRIPTION
### Pull request checklist

-   [x] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

If sorting was enabled for a collection, but the list of sortables was empty, the sortby parameter accepted any property of the feature type, because the enum of allowed sort keys was only set for a non-empty list of sortables.

- the sortby parameter is no longer available for collections that have neither sortables nor a default sort order
- if only a default sort order is configured, the parameter remains available, but all client-provided sort keys are rejected
- add a spec for the sortby parameter
