### PR TITLE
fix rejection of queryable query parameter values with a wildcard

### DIFF
--- a/ogcapi-stable/ogcapi-collections-queryables/src/main/java/de/ii/ogcapi/collections/queryables/app/QueryParametersQueryables.java
+++ b/ogcapi-stable/ogcapi-collections-queryables/src/main/java/de/ii/ogcapi/collections/queryables/app/QueryParametersQueryables.java
@@ -145,6 +145,13 @@ public class QueryParametersQueryables
     } else {
       description.append('.');
     }
+    if (QueryParameterTemplateQueryable.supportsWildcard(
+        queryableDefinition.getValue().getType(), queryableDefinition.getValue().getValueType())) {
+      description.append(
+          " The value may contain '*' as a wildcard for any sequence of characters. Schema"
+              + " constraints of the property, for example 'pattern' or 'enum', are not applied to"
+              + " values with a wildcard.");
+    }
     return new ImmutableQueryParameterTemplateQueryable.Builder()
         .apiId(apiData.getId())
         .collectionId(collectionData.getId())

--- a/ogcapi-stable/ogcapi-collections-queryables/src/main/java/de/ii/ogcapi/collections/queryables/domain/QueryParameterTemplateQueryable.java
+++ b/ogcapi-stable/ogcapi-collections-queryables/src/main/java/de/ii/ogcapi/collections/queryables/domain/QueryParameterTemplateQueryable.java
@@ -33,6 +33,8 @@ import de.ii.xtraplatform.cql.domain.TemporalLiteral;
 import de.ii.xtraplatform.features.domain.SchemaBase;
 import de.ii.xtraplatform.features.domain.SchemaBase.Type;
 import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -84,6 +86,35 @@ public abstract class QueryParameterTemplateQueryable extends OgcApiQueryParamet
   @Override
   public Schema<?> getSchema(OgcApiDataV2 apiData) {
     return getSchema();
+  }
+
+  /**
+   * Whether a value of this parameter may contain a wildcard, that is, whether {@link #parse} maps
+   * a value with a wildcard to a LIKE/ALIKE predicate. This is the case for string-valued
+   * queryables, including arrays of strings.
+   */
+  public static boolean supportsWildcard(Type type, Optional<Type> valueType) {
+    if (type == Type.VALUE_ARRAY) {
+      return valueType.orElse(Type.STRING) == Type.STRING;
+    }
+    return valueType.orElse(type) == Type.STRING;
+  }
+
+  @Override
+  public Schema<?> getSchemaForValidation(
+      OgcApiDataV2 apiData, Optional<String> collectionId, List<String> values) {
+    if (!supportsWildcard(getType(), getValueType())
+        || values.stream().noneMatch(v -> Objects.nonNull(v) && v.contains("*"))) {
+      return getSchema();
+    }
+
+    // a value with a wildcard is a pattern, not a value of the property, so the constraints of the
+    // property (pattern, enum, format, length, ...) cannot be applied to it; for arrays the pattern
+    // is matched against the array members, so the value is a single string, not a list of values
+    StringSchema schema = new StringSchema();
+    schema.setTitle(getSchema().getTitle());
+    schema.setDescription(getSchema().getDescription());
+    return schema;
   }
 
   @Override

--- a/ogcapi-stable/ogcapi-collections-queryables/src/main/java/de/ii/ogcapi/collections/queryables/domain/QueryablesConfiguration.java
+++ b/ogcapi-stable/ogcapi-collections-queryables/src/main/java/de/ii/ogcapi/collections/queryables/domain/QueryablesConfiguration.java
@@ -132,9 +132,15 @@ public interface QueryablesConfiguration
 
   /**
    * @langEn If `true`, all queryables with a simple value (string, number or boolean) will be
-   *     provided query parameters to filter features.
+   *     provided query parameters to filter features. For queryables with a string value, the value
+   *     of the query parameter may contain `*` as a wildcard for any sequence of characters. Such a
+   *     value is a pattern, so the schema constraints of the property, for example `pattern` or
+   *     `enum`, are not applied to it.
    * @langDe Bei `true` werden alle Queryables mit einem einfachen Wert (String, Zahl oder Boolean)
-   *     als Query-Parameter zum Filtern der Features bereitgestellt.
+   *     als Query-Parameter zum Filtern der Features bereitgestellt. Bei Queryables mit einem
+   *     Zeichenkettenwert kann der Wert des Query-Parameters `*` als Platzhalter für eine beliebige
+   *     Zeichenfolge enthalten. Ein solcher Wert ist ein Suchmuster, die Schema-Constraints der
+   *     Eigenschaft, zum Beispiel `pattern` oder `enum`, werden daher nicht auf ihn angewendet.
    * @default true
    * @since v3.4
    */

--- a/ogcapi-stable/ogcapi-collections-queryables/src/test/groovy/de/ii/ogcapi/collections/queryables/domain/QueryParameterTemplateQueryableSpec.groovy
+++ b/ogcapi-stable/ogcapi-collections-queryables/src/test/groovy/de/ii/ogcapi/collections/queryables/domain/QueryParameterTemplateQueryableSpec.groovy
@@ -8,23 +8,42 @@
 package de.ii.ogcapi.collections.queryables.domain
 
 import de.ii.ogcapi.foundation.domain.SchemaValidator
+import de.ii.ogcapi.foundation.infra.json.SchemaValidatorImpl
 import de.ii.xtraplatform.cql.domain.Eq
 import de.ii.xtraplatform.features.domain.SchemaBase
+import io.swagger.v3.oas.models.media.ArraySchema
+import io.swagger.v3.oas.models.media.IntegerSchema
+import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.media.StringSchema
 import spock.lang.Specification
 
 class QueryParameterTemplateQueryableSpec extends Specification {
 
-    def queryable(SchemaBase.Type type) {
-        return new ImmutableQueryParameterTemplateQueryable.Builder()
+    static final String ID_PATTERN = '^DEXX[A-Za-z0-9]{12}$'
+
+
+    static final SchemaValidator ACCEPT_ALL = { schema, value -> Optional.empty() } as SchemaValidator
+
+    def queryable(SchemaBase.Type type,
+                  Schema<?> schema = new StringSchema(),
+                  SchemaBase.Type valueType = null,
+                  SchemaValidator validator = ACCEPT_ALL) {
+        def builder = new ImmutableQueryParameterTemplateQueryable.Builder()
                 .apiId("api")
                 .collectionId("collection")
                 .name("lzi.end")
                 .description("a queryable")
-                .schema(new StringSchema())
-                .schemaValidator({ schema, value -> Optional.empty() } as SchemaValidator)
+                .schema(schema)
+                .schemaValidator(validator)
                 .type(type)
-                .build()
+        if (valueType != null) {
+            builder.valueType(valueType)
+        }
+        return builder.build()
+    }
+
+    def idQueryable(SchemaValidator validator = ACCEPT_ALL) {
+        return queryable(SchemaBase.Type.STRING, new StringSchema().pattern(ID_PATTERN), null, validator)
     }
 
     def 'invalid temporal value raises a client error, not a CQL parse error'() {
@@ -60,5 +79,79 @@ class QueryParameterTemplateQueryableSpec extends Specification {
 
         then:
         thrown(IllegalArgumentException)
+    }
+
+    def 'a value without a wildcard is validated against the schema of the property'() {
+        given:
+        def parameter = idQueryable()
+
+        when:
+        def schema = parameter.getSchemaForValidation(null, Optional.empty(), ["DEXX123456789012"])
+
+        then:
+        schema.pattern == ID_PATTERN
+    }
+
+    def 'a value with a wildcard is validated without the constraints of the property'() {
+        given:
+        def parameter = idQueryable()
+
+        when:
+        def schema = parameter.getSchemaForValidation(null, Optional.empty(), ["DEXX1*"])
+
+        then:
+        schema.type == "string"
+        schema.pattern == null
+    }
+
+    def 'the constraints are kept for queryables that do not support wildcards'() {
+        given:
+        def parameter = queryable(SchemaBase.Type.INTEGER, new IntegerSchema().maximum(100g))
+
+        when:
+        def schema = parameter.getSchemaForValidation(null, Optional.empty(), ["1*"])
+
+        then:
+        schema.maximum == 100g
+    }
+
+    def 'a value with a wildcard for an array queryable is validated as a single pattern'() {
+        given:
+        def schema = new ArraySchema().items(new StringSchema().pattern(ID_PATTERN))
+        def parameter = queryable(SchemaBase.Type.VALUE_ARRAY, schema, SchemaBase.Type.STRING)
+
+        when:
+        // the value is one ALIKE pattern, not a list of values, so it must not be split on the comma
+        def validationSchema = parameter.getSchemaForValidation(null, Optional.empty(), ["DEXX1*,DEXX2"])
+
+        then:
+        validationSchema.type == "string"
+    }
+
+    def 'the constraints are kept for arrays that do not have string values'() {
+        given:
+        def schema = new ArraySchema().items(new IntegerSchema())
+        def parameter = queryable(SchemaBase.Type.VALUE_ARRAY, schema, SchemaBase.Type.INTEGER)
+
+        when:
+        def validationSchema = parameter.getSchemaForValidation(null, Optional.empty(), ["1*"])
+
+        then:
+        validationSchema.type == "array"
+    }
+
+    def 'a value with a wildcard is accepted, a value that violates the constraints is rejected'() {
+        given:
+        def parameter = idQueryable(new SchemaValidatorImpl())
+
+        expect:
+        parameter.validate(null, Optional.empty(), [value]).isPresent() == invalid
+
+        where:
+        value              || invalid
+        "DEXX123456789012" || false
+        "DEXX1*"           || false
+        "*"                || false
+        "DEXX1"            || true
     }
 }

--- a/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ParameterExtension.java
+++ b/ogcapi-stable/ogcapi-foundation/src/main/java/de/ii/ogcapi/foundation/domain/ParameterExtension.java
@@ -74,6 +74,16 @@ public interface ParameterExtension extends ApiExtension {
     return false;
   }
 
+  /**
+   * The schema that is used to validate the parameter values. By default this is the schema that is
+   * also published in the API definition. Parameters that accept additional value forms, for
+   * example wildcards, can relax the schema depending on the values that were submitted.
+   */
+  default Schema<?> getSchemaForValidation(
+      OgcApiDataV2 apiData, Optional<String> collectionId, List<String> values) {
+    return getSchema(apiData, collectionId);
+  }
+
   default Optional<String> validate(
       OgcApiDataV2 apiData, Optional<String> collectionId, List<String> values) {
     // first validate against the schema
@@ -98,7 +108,7 @@ public interface ParameterExtension extends ApiExtension {
   default Optional<String> validateSchema(
       OgcApiDataV2 apiData, Optional<String> collectionId, List<String> values) {
     try {
-      Schema<?> schema = getSchema(apiData, collectionId);
+      Schema<?> schema = getSchemaForValidation(apiData, collectionId, values);
       if (Objects.isNull(schema)) {
         // a parameter without a schema cannot be schema-validated; validateOther() still runs
         LOGGER.warn(


### PR DESCRIPTION
### Pull request checklist

-   [x] Added/updated unit tests
-   [x] Updated documentation
-   [x] All checks are passing

### Changes introduced by this PR

Closes #1764.

A queryable query parameter was always validated against the schema of the property, so a value with a wildcard was rejected whenever the property has constraints that the wildcard pattern cannot satisfy, for example a regular expression, an enum or a length restriction.

The values are available when a parameter is validated, only the typed parsing happens later, so the schema can be selected per request. Add the hook getSchemaForValidation() to ParameterExtension and use it in validateSchema(). The schema that is published in the API definition is unchanged.

For a queryable that supports a wildcard, that is a string value or an array of strings, a value with a wildcard is now validated against a plain string schema. A string schema also for arrays, because such a value is a single pattern that is matched against the array members and must not be split at the comma. Values without a wildcard, and queryables that do not support one, keep the schema of the property and are still rejected when they violate it.

