### PR TITLE
CRUD/TRANSACTIONS: add an option to reject empty values

### DIFF
--- a/gradle/layers.versions.toml
+++ b/gradle/layers.versions.toml
@@ -1,5 +1,5 @@
 [versions]
 xtraplatform-core    = '7.1.0-SNAPSHOT'
 xtraplatform-native  = '2.7.0-SNAPSHOT'
-xtraplatform-spatial = '8.1.0-SNAPSHOT'
+xtraplatform-spatial = '8.1.0-reject-empty-values-SNAPSHOT'
 

--- a/gradle/layers.versions.toml
+++ b/gradle/layers.versions.toml
@@ -1,5 +1,5 @@
 [versions]
 xtraplatform-core    = '7.1.0-SNAPSHOT'
 xtraplatform-native  = '2.7.0-SNAPSHOT'
-xtraplatform-spatial = '8.1.0-reject-empty-values-SNAPSHOT'
+xtraplatform-spatial = '8.1.0-SNAPSHOT'
 

--- a/ldproxy-cfg/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/ldproxy-cfg/src/main/resources/META-INF/native-image/reflect-config.json
@@ -12119,6 +12119,10 @@
       {
         "parameterTypes": [],
         "name": "getOptimisticLockingLastModified"
+      },
+      {
+        "parameterTypes": [],
+        "name": "getRejectEmptyValues"
       }
     ]
   },
@@ -12147,6 +12151,12 @@
           "java.lang.Boolean"
         ],
         "name": "optimisticLockingLastModified"
+      },
+      {
+        "parameterTypes": [
+          "java.lang.Boolean"
+        ],
+        "name": "rejectEmptyValues"
       },
       {
         "parameterTypes": [],

--- a/ldproxy-cfg/src/main/resources/json-schema/entities/services.json
+++ b/ldproxy-cfg/src/main/resources/json-schema/entities/services.json
@@ -5200,6 +5200,22 @@
             }
           ]
         },
+        "rejectEmptyValues": {
+          "title": "rejectEmptyValues",
+          "description": "Option to reject empty values in a transaction. A value is empty, if it is a string    without characters or with only whitespace. The check is only applied to requests with a    `Prefer` header with the value \"handling\u003dstrict\"; it covers the feature payload of every    `insert` and `replace` action as well as every value set by an `update` action, and the    response states the first empty value of the rejected action. Values of other types cannot    be empty, so where schema validation is also active an empty value can only occur in a    string. The payload is checked while it is decoded, so the check needs no schema and is    also applied where none is available; a property the payload omits, or states as null, is    left without a value and is not affected. Because the check rides the decoding rather than    running before the write, an empty value fails the whole action, also under batch    semantics, instead of skipping just the item that carries it.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "pattern": "y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "updatableProperties": {
           "title": "updatableProperties",
           "description": "Whitelist of feature properties that may be the target of a partial update (the    `wfs:Update` action of a `wfs:Transaction`, or the JSON-transaction `update` action). Each    entry is a property path written as the schema property identifiers joined by `.`, e.g.    `lifetime.end` for a nested property or `name` for a top-level scalar. Path segments are    always the canonical schema identifiers, independent of the input format\u0027s alias setting. A    partial update whose property path is not in this list is rejected with a 4xx error.      Entries set at the API level apply to every collection; entries set on a specific    collection are merged with the API-level list (duplicates de-duplicated). When the    effective list for a collection is empty, partial updates are disabled for that collection.",
@@ -5506,6 +5522,22 @@
         "optimisticLockingLastModified": {
           "title": "optimisticLockingLastModified",
           "description": "Option to enable support for conditional processing of PUT, PATCH, and DELETE requests,    based on the time when the feature was last updated. Such requests must include an    `If-Unmodified-Since` header, otherwise they will be rejected. A feature will only be    changed, if the feature was not changed since the timestamp in the header (or if no last    modification time is known for the feature). The last modification time of a feature is    determined from a feature property with type `DATETIME` for which `isLastModified` is set    to true in the schema in the feature provider.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "pattern": "y|Y|yes|Yes|YES|n|N|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rejectEmptyValues": {
+          "title": "rejectEmptyValues",
+          "description": "Option to reject empty values in the request body of a POST or PUT request. A value is    empty, if it is a string without characters or with only whitespace. The check is only    applied to requests with a `Prefer` header with the value \"handling\u003dstrict\"; such a request    is rejected with HTTP 400 (\"Bad Request\") and the response states the first empty value.    Values of other types cannot be empty, so where schema validation is also active an empty    value can only occur in a string. The check is applied while the request body is decoded,    so it needs no schema and is also applied, if no schema is available for validating the    request body. A property that the request body omits, or states as null, is left without a    value and is not affected.",
           "oneOf": [
             {
               "type": "boolean"

--- a/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/app/CommandHandlerCrud.java
+++ b/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/app/CommandHandlerCrud.java
@@ -48,6 +48,15 @@ public interface CommandHandlerCrud extends Volatile2 {
 
     boolean getValidate();
 
+    /**
+     * Whether an empty value in the request body makes it invalid. Only ever true together with
+     * {@link #getValidate()}, i.e. for a request with {@code Prefer: handling=strict}.
+     */
+    @Value.Default
+    default boolean getRejectEmptyValues() {
+      return false;
+    }
+
     @Value.Default
     default List<String> getLinkHeaders() {
       return List.of();

--- a/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/app/CommandHandlerCrudImpl.java
+++ b/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/app/CommandHandlerCrudImpl.java
@@ -156,7 +156,8 @@ public class CommandHandlerCrudImpl extends AbstractVolatileComposed implements 
         requestContext.getApi().getData(),
         queryInput.getCollectionId(),
         crs,
-        axes);
+        axes,
+        queryInput.getRejectEmptyValues());
   }
 
   private Response createFeature(
@@ -666,7 +667,8 @@ public class CommandHandlerCrudImpl extends AbstractVolatileComposed implements 
       OgcApiDataV2 apiData,
       String collectionId,
       EpsgCrs crs,
-      Axes axes) {
+      Axes axes,
+      boolean rejectEmptyValues) {
 
     FeatureFormatExtension format = resolveFormat(contentType);
 
@@ -686,6 +688,8 @@ public class CommandHandlerCrudImpl extends AbstractVolatileComposed implements 
             .supportedCrs(supportedCrs)
             // a body that sets a read-only property is rejected, not silently stripped of the value
             .readOnlyProperties(ReadOnlyProperties.of(featureSchema))
+            // an empty value is rejected while the body is decoded, so it costs no second parse
+            .rejectEmptyValues(rejectEmptyValues)
             .build();
 
     return Source.inputStream(requestBody).via(format.getFeatureDecoder(ctx).get());

--- a/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/app/CrudBuildingBlock.java
+++ b/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/app/CrudBuildingBlock.java
@@ -85,6 +85,10 @@ import org.slf4j.LoggerFactory;
  *     header. The validation requires a schema: the building block SCHEMA_VALIDATION for GeoJSON
  *     and JSON-FG, the option "schemaLocations" of the GML building block for GML. Without it, the
  *     request body is not validated and the preference is ignored.
+ *     <p>The option `rejectEmptyValues` adds a second check to "handling=strict": the request is
+ *     rejected, if any value in the request body is an empty string or consists only of whitespace.
+ *     The check is applied while the request body is decoded, so it needs no schema and is also
+ *     applied where the request body cannot be validated against one.
  *     <p>A PUT, PATCH or DELETE request cannot be made conditional on an entity tag: no entity tag
  *     is known for the feature in a request that changes it, so an "If-Match" header cannot be met
  *     and the request is rejected with HTTP 412 ("Precondition Failed"). Use an
@@ -152,6 +156,11 @@ import org.slf4j.LoggerFactory;
  *     Validierung wird ein Schema benötigt: der Baustein SCHEMA_VALIDATION bei GeoJSON und JSON-FG,
  *     die Option "schemaLocations" des GML-Bausteins bei GML. Ohne ein Schema wird der Payload
  *     nicht validiert und die Präferenz ignoriert.
+ *     <p>Die Option `rejectEmptyValues` ergänzt "handling=strict" um eine zweite Prüfung: Die
+ *     Anfrage wird zurückgewiesen, wenn ein Wert im Payload eine leere Zeichenkette ist oder nur
+ *     aus Leerraum besteht. Die Prüfung erfolgt beim Dekodieren des Payloads, benötigt daher kein
+ *     Schema und wird auch angewendet, wenn der Payload nicht gegen ein Schema validiert werden
+ *     kann.
  *     <p>Eine PUT-, PATCH- oder DELETE-Anfrage kann nicht von einem Entity-Tag abhängig gemacht
  *     werden: In einer Anfrage, die ein Feature ändert, ist kein Entity-Tag des Features bekannt,
  *     daher kann ein "If-Match"-Header nicht erfüllt werden und die Anfrage wird mit HTTP 412

--- a/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/app/EndpointCrud.java
+++ b/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/app/EndpointCrud.java
@@ -184,24 +184,33 @@ public class EndpointCrud extends EndpointSubCollection
     }
 
     if (apiData.getCollections().keySet().stream()
-        .anyMatch(collectionId -> canValidate(apiData, collectionId))) {
+        .anyMatch(collectionId -> appliesStrictHandling(apiData, collectionId))) {
       builder.add(CONF_CLASS_PREFIX + "handling");
     }
 
     return builder.build();
   }
 
-  // The request body of a mutation request is validated for "Prefer: handling=strict", if any of
-  // the formats that are supported in mutation requests can validate a request body.
-  private boolean canValidate(OgcApiDataV2 apiData, String collectionId) {
+  // "Prefer: handling=strict" has an effect on a mutation request, if any of the formats that are
+  // supported in mutation requests can validate a request body against a schema, or if empty values
+  // are rejected (that check needs no schema).
+  private boolean appliesStrictHandling(OgcApiDataV2 apiData, String collectionId) {
     return isEnabledForApi(apiData, collectionId)
-        && transactionFormats().stream().anyMatch(f -> f.canValidate(apiData, collectionId));
+        && (rejectsEmptyValues(apiData, collectionId)
+            || transactionFormats().stream().anyMatch(f -> f.canValidate(apiData, collectionId)));
   }
 
   private boolean canValidate(OgcApiDataV2 apiData, String collectionId, MediaType contentType) {
     return transactionFormat(contentType)
         .filter(format -> format.canValidate(apiData, collectionId))
         .isPresent();
+  }
+
+  private static boolean rejectsEmptyValues(OgcApiDataV2 apiData, String collectionId) {
+    return apiData
+        .getExtension(CrudConfiguration.class, collectionId)
+        .map(CrudConfiguration::rejectsEmptyValues)
+        .orElse(false);
   }
 
   private List<FeatureFormatExtension> transactionFormats() {
@@ -515,6 +524,7 @@ public class EndpointCrud extends EndpointSubCollection
             .requestBody(requestBody)
             .contentType(contentType)
             .validate(validate)
+            .rejectEmptyValues(rejectEmptyValues(api.getData(), collectionId, prefer))
             .linkHeaders(links)
             .build();
 
@@ -613,6 +623,7 @@ public class EndpointCrud extends EndpointSubCollection
             .requestBody(requestBody)
             .contentType(contentType)
             .validate(validate)
+            .rejectEmptyValues(rejectEmptyValues(api.getData(), collectionId, prefer))
             .linkHeaders(links)
             .profiles(crudProfiles)
             .isAllowCreate(!hasGeneratedId(api.getData(), collectionId))
@@ -819,9 +830,19 @@ public class EndpointCrud extends EndpointSubCollection
 
   private boolean validateRequestBody(
       OgcApiDataV2 apiData, String collectionId, MediaType contentType, List<String> prefer) {
+    return isStrict(prefer) && canValidate(apiData, collectionId, contentType);
+  }
+
+  // The empty-value check is applied while the request body is decoded, so unlike schema validation
+  // it does not depend on a schema being available for the collection.
+  private static boolean rejectEmptyValues(
+      OgcApiDataV2 apiData, String collectionId, List<String> prefer) {
+    return isStrict(prefer) && rejectsEmptyValues(apiData, collectionId);
+  }
+
+  private static boolean isStrict(List<String> prefer) {
     return HeaderPrefer.parseHandling(prefer, HeaderPrefer.Handling.LENIENT)
-            == HeaderPrefer.Handling.STRICT
-        && canValidate(apiData, collectionId, contentType);
+        == HeaderPrefer.Handling.STRICT;
   }
 
   // The strict handling preference has been applied, so the rejection of the request body reports

--- a/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/app/HeaderPreferFeature.java
+++ b/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/app/HeaderPreferFeature.java
@@ -37,7 +37,8 @@ public class HeaderPreferFeature extends HeaderPrefer {
   @Override
   public String getDescription() {
     return "'handling=strict' creates or replaces the feature after successful validation. Status 400 is returned, "
-        + "if validation fails. 'handling=lenient' (the default) creates or replaces the feature without validation.";
+        + "if validation fails. Where the 'rejectEmptyValues' option is enabled, a request body with an empty value "
+        + "fails validation, too. 'handling=lenient' (the default) creates or replaces the feature without validation.";
   }
 
   @Override

--- a/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/domain/CrudConfiguration.java
+++ b/ogcapi-draft/ogcapi-crud/src/main/java/de/ii/ogcapi/crud/domain/CrudConfiguration.java
@@ -22,6 +22,7 @@ import org.immutables.value.Value;
  * ```yaml
  * - buildingBlock: CRUD
  *   enabled: true
+ *   rejectEmptyValues: true
  * ```
  * </code>
  */
@@ -66,6 +67,39 @@ public interface CrudConfiguration extends ExtensionConfiguration {
   @Value.Auxiliary
   default boolean supportsLastModified() {
     return Objects.equals(getOptimisticLockingLastModified(), true);
+  }
+
+  /**
+   * @langEn Option to reject empty values in the request body of a POST or PUT request. A value is
+   *     empty, if it is a string without characters or with only whitespace. The check is only
+   *     applied to requests with a `Prefer` header with the value "handling=strict"; such a request
+   *     is rejected with HTTP 400 ("Bad Request") and the response states the first empty value.
+   *     Values of other types cannot be empty, so where schema validation is also active an empty
+   *     value can only occur in a string. The check is applied while the request body is decoded,
+   *     so it needs no schema and is also applied, if no schema is available for validating the
+   *     request body. A property that the request body omits, or states as null, is left without a
+   *     value and is not affected.
+   * @langDe Option zur Zurückweisung leerer Werte im Request-Body einer POST- oder PUT-Anfrage. Ein
+   *     Wert ist leer, wenn es eine Zeichenkette ohne Zeichen oder nur mit Leerraum ist. Die
+   *     Prüfung wird nur auf Anfragen mit einem `Prefer`-Header mit dem Wert "handling=strict"
+   *     angewendet; eine solche Anfrage wird mit HTTP 400 ("Bad Request") zurückgewiesen und die
+   *     Antwort benennt den ersten leeren Wert. Werte anderer Datentypen können nicht leer sein,
+   *     d.h. wenn zusätzlich die Schemavalidierung aktiv ist, kann ein leerer Wert nur in einer
+   *     Zeichenkette auftreten. Die Prüfung erfolgt beim Dekodieren des Request-Body, benötigt
+   *     daher kein Schema und wird auch angewendet, wenn kein Schema für die Validierung des
+   *     Request-Body verfügbar ist. Eine Eigenschaft, die im Request-Body fehlt oder als null
+   *     angegeben ist, bleibt ohne Wert und ist nicht betroffen.
+   * @default false
+   * @since v4.9
+   */
+  @Nullable
+  Boolean getRejectEmptyValues();
+
+  @JsonIgnore
+  @Value.Derived
+  @Value.Auxiliary
+  default boolean rejectsEmptyValues() {
+    return Objects.equals(getRejectEmptyValues(), true);
   }
 
   abstract class Builder extends ExtensionConfiguration.Builder {}

--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/HeaderPreferTransaction.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/HeaderPreferTransaction.java
@@ -58,7 +58,8 @@ public class HeaderPreferTransaction extends HeaderPrefer {
         + "Response is still returned when the transaction failed, so that exceptions can be "
         + "reported). Malformed transaction envelopes are rejected while parsing. "
         + "'handling=strict' validates each feature payload against its schema before any provider "
-        + "write. 'handling=lenient' (the default) skips feature schema validation and only fails "
+        + "write and, if the 'rejectEmptyValues' option is enabled, rejects an action that would "
+        + "write an empty value. 'handling=lenient' (the default) skips these checks and only fails "
         + "on malformed requests or errors raised by the provider. 'respond-async' is not "
         + "supported and results in 501 Not Implemented.";
   }

--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/TransactionExecutorImpl.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/TransactionExecutorImpl.java
@@ -14,6 +14,7 @@ import com.google.common.collect.ImmutableList;
 import de.ii.ogcapi.collections.schema.domain.SchemaConfiguration;
 import de.ii.ogcapi.crs.domain.CrsSupport;
 import de.ii.ogcapi.features.core.domain.DecoderContext;
+import de.ii.ogcapi.features.core.domain.EmptyValues;
 import de.ii.ogcapi.features.core.domain.FeatureFormatExtension;
 import de.ii.ogcapi.features.core.domain.FeaturesCoreConfiguration;
 import de.ii.ogcapi.features.core.domain.FeaturesCoreProviders;
@@ -76,6 +77,7 @@ import de.ii.xtraplatform.features.domain.ImmutableFeatureChange;
 import de.ii.xtraplatform.features.domain.ImmutablePropertyUpdate;
 import de.ii.xtraplatform.features.domain.SchemaBase;
 import de.ii.xtraplatform.features.domain.Tuple;
+import de.ii.xtraplatform.features.domain.pipeline.FeatureEventHandlerEmptyValues;
 import de.ii.xtraplatform.geometries.domain.Axes;
 import de.ii.xtraplatform.streams.domain.Reactive.Source;
 import jakarta.inject.Inject;
@@ -527,6 +529,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
                 requestCrs,
                 touchedIdsByCollection,
                 fromWfs,
+                validate,
                 strategy,
                 mutationTimestamp);
         case DELETE ->
@@ -571,6 +574,9 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
     List<String> skippedPayloads = new ArrayList<>();
     List<String> skippedErrors = new ArrayList<>();
 
+    // `validate` is the request's strict-handling preference, so the empty-value check is gated on
+    // it too; unlike schema validation it rides the decoding and needs no schema.
+    boolean rejectEmptyValues = validate && rejectsEmptyValues(apiData, canonicalCollectionId);
     FeatureFormatExtension format = validate ? resolveFormat(action.getMediaType()) : null;
     ValidatorContext vctx =
         validate
@@ -662,7 +668,8 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
                 apiData,
                 action.getCollectionId(),
                 requestCrs,
-                axes);
+                axes,
+                rejectEmptyValues);
         if (needsIdOverride) {
           // Composite gml:id was carrying a uniqueness suffix; flush the current batch and write
           // this item on its own with an extra ID role override forcing the canonical id into
@@ -901,7 +908,8 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
               apiData,
               action.getCollectionId(),
               requestCrs,
-              axes);
+              axes,
+              validate && rejectsEmptyValues(apiData, canonicalCollectionId));
       if (strategy.retiresOnReplace()) {
         // Versioned Replace: retire the open version (`PRIMARY_INTERVAL_END = ts WHERE
         // PRIMARY_INTERVAL_END IS NULL AND startCol < ts [AND startCol = <expectedStart>]`),
@@ -998,6 +1006,7 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
       EpsgCrs requestCrs,
       Map<String, Set<String>> touchedIdsByCollection,
       boolean fromWfs,
+      boolean validate,
       MutationStrategy strategy,
       Instant mutationTimestamp) {
     EpsgCrs crs = requestCrs;
@@ -1040,6 +1049,9 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
     List<FeatureTransactions.PropertyUpdate> updates;
     try {
       updates = buildPropertyUpdates(action, apiData, canonicalCollectionId, fromWfs, crs);
+      if (validate && rejectsEmptyValues(apiData, canonicalCollectionId)) {
+        rejectEmptyValues(updates);
+      }
     } catch (RuntimeException e) {
       // Action-level failure (bad payload, non-whitelisted property, unknown path, etc.) —
       // attribute it to every target id so the log line and the result both name the
@@ -1250,6 +1262,23 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
     return ImmutablePropertyUpdate.builder().path(canonicalPath).value(Optional.of(value)).build();
   }
 
+  // A partial update carries the new values themselves rather than a feature payload, so the
+  // empty-value check runs on the resolved values instead of going through the input format. An
+  // explicit delete (`value` absent) sets the property to null, which is not an empty value.
+  // Package-private so a spec can exercise the check on its own (see runAction above).
+  static void rejectEmptyValues(List<FeatureTransactions.PropertyUpdate> updates) {
+    for (FeatureTransactions.PropertyUpdate update : updates) {
+      if (update.getValue().isEmpty()) {
+        continue;
+      }
+      Optional<String> emptyValue = EmptyValues.firstEmptyValue(update.getValue().get());
+      if (emptyValue.isPresent()) {
+        throw FeatureEventHandlerEmptyValues.rejected(
+            EmptyValues.join(String.join(".", update.getPath()), emptyValue.get()));
+      }
+    }
+  }
+
   private static List<String> resolveAndCheck(
       FeatureSchema root,
       List<String> inputPath,
@@ -1271,6 +1300,13 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
               + "'. Configure the TRANSACTIONS building block's `updatableProperties` to opt in.");
     }
     return canonicalPath;
+  }
+
+  private static boolean rejectsEmptyValues(OgcApiDataV2 apiData, String canonicalCollectionId) {
+    return resolveCollection(apiData, canonicalCollectionId)
+        .getExtension(TransactionsConfiguration.class)
+        .map(TransactionsConfiguration::rejectsEmptyValues)
+        .orElse(false);
   }
 
   private static List<List<String>> updatablePaths(
@@ -1752,7 +1788,8 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
       OgcApiDataV2 apiData,
       String collectionId,
       EpsgCrs crs,
-      Axes axes) {
+      Axes axes,
+      boolean rejectEmptyValues) {
     FeatureFormatExtension format = resolveFormat(contentType);
     FeatureTypeConfigurationOgcApi collectionCfg = resolveCollection(apiData, collectionId);
     FeatureSchema featureSchema =
@@ -1774,6 +1811,8 @@ public class TransactionExecutorImpl extends AbstractVolatileComposed
             .supportedCrs(supportedCrs)
             // a body that sets a read-only property is rejected, not silently stripped of the value
             .readOnlyProperties(ReadOnlyProperties.of(featureSchema))
+            // an empty value is rejected while the payload is decoded, so it costs no second parse
+            .rejectEmptyValues(rejectEmptyValues)
             .mediaType(contentType)
             .build();
     return Source.inputStream(body).via(format.getFeatureDecoder(dctx).get());

--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/TransactionsBuildingBlock.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/app/TransactionsBuildingBlock.java
@@ -41,6 +41,12 @@ import org.slf4j.LoggerFactory;
  *     feature-type schema before any provider write (this only takes effect when the collection has
  *     schema validation configured: JSON Schema for GeoJSON payloads, XSD for GML payloads).
  *     `respond-async` is rejected with `501`.
+ *     <p>The option `rejectEmptyValues` adds a second check to `handling=strict`: an action is
+ *     rejected, if a value it writes is an empty string or consists only of whitespace. It covers
+ *     `insert` and `replace` payloads as well as the values set by an `update` action. A payload is
+ *     checked while it is decoded, so the check needs no schema and also takes effect where the
+ *     payload cannot be validated against one; an empty value therefore fails the whole action
+ *     rather than skipping the item that carries it.
  *     <p>The `Content-Crs` request header declares the CRS of coordinates in the request body. When
  *     omitted, the API's default CRS (CRS84 unless overridden) is assumed; values that are
  *     syntactically invalid or name a CRS not in the API's supported list are rejected with a `4xx`
@@ -63,6 +69,13 @@ import org.slf4j.LoggerFactory;
  *     Schema der Objektart (greift nur, wenn die Objektart eine Schema-Validierung konfiguriert
  *     hat: JSON Schema für GeoJSON-Payloads, XSD für GML-Payloads). `respond-async` wird mit `501`
  *     abgelehnt.
+ *     <p>Die Option `rejectEmptyValues` ergänzt `handling=strict` um eine zweite Prüfung: Eine
+ *     Aktion wird zurückgewiesen, wenn ein von ihr geschriebener Wert eine leere Zeichenkette ist
+ *     oder nur aus Leerraum besteht. Sie erfasst `insert`- und `replace`-Payloads ebenso wie die
+ *     von einer `update`-Aktion gesetzten Werte. Ein Payload wird beim Dekodieren geprüft; die
+ *     Prüfung benötigt daher kein Schema und greift auch dann, wenn der Payload nicht gegen ein
+ *     Schema validiert werden kann. Ein leerer Wert lässt daher die gesamte Aktion scheitern, statt
+ *     nur das betroffene Element zu überspringen.
  *     <p>Der Anfrage-Header `Content-Crs` gibt das CRS der Koordinaten im Anfragetext an. Fehlt der
  *     Header, wird das Standard-CRS der API angenommen (CRS84, sofern nicht überschrieben);
  *     syntaktisch ungültige Werte oder ein nicht von der API unterstütztes CRS werden mit einem

--- a/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/TransactionsConfiguration.java
+++ b/ogcapi-draft/ogcapi-transactions/src/main/java/de/ii/ogcapi/transactions/domain/TransactionsConfiguration.java
@@ -7,6 +7,7 @@
  */
 package de.ii.ogcapi.transactions.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableList;
 import de.ii.ogcapi.foundation.domain.ExtensionConfiguration;
@@ -26,6 +27,7 @@ import org.immutables.value.Value;
  *   wfsTransaction: false
  *   defaultSemantic: ATOMIC
  *   collectErrors: true
+ *   rejectEmptyValues: true
  * ```
  *
  * Per-collection partial-update whitelist (allows `wfs:Update` / JSON-transaction `update`
@@ -167,6 +169,43 @@ public interface TransactionsConfiguration extends ExtensionConfiguration {
    */
   @Nullable
   Boolean getCollectErrors();
+
+  /**
+   * @langEn Option to reject empty values in a transaction. A value is empty, if it is a string
+   *     without characters or with only whitespace. The check is only applied to requests with a
+   *     `Prefer` header with the value "handling=strict"; it covers the feature payload of every
+   *     `insert` and `replace` action as well as every value set by an `update` action, and the
+   *     response states the first empty value of the rejected action. Values of other types cannot
+   *     be empty, so where schema validation is also active an empty value can only occur in a
+   *     string. The payload is checked while it is decoded, so the check needs no schema and is
+   *     also applied where none is available; a property the payload omits, or states as null, is
+   *     left without a value and is not affected. Because the check rides the decoding rather than
+   *     running before the write, an empty value fails the whole action, also under batch
+   *     semantics, instead of skipping just the item that carries it.
+   * @langDe Option zur Zurückweisung leerer Werte in einer Transaktion. Ein Wert ist leer, wenn es
+   *     eine Zeichenkette ohne Zeichen oder nur mit Leerraum ist. Die Prüfung wird nur auf Anfragen
+   *     mit einem `Prefer`-Header mit dem Wert "handling=strict" angewendet; sie erfasst den
+   *     Feature-Payload jeder `insert`- und `replace`-Aktion sowie jeden von einer `update`-Aktion
+   *     gesetzten Wert, und die Antwort benennt den ersten leeren Wert der zurückgewiesenen Aktion.
+   *     Werte anderer Datentypen können nicht leer sein, d.h. wenn zusätzlich die Schemavalidierung
+   *     aktiv ist, kann ein leerer Wert nur in einer Zeichenkette auftreten. Der Payload wird beim
+   *     Dekodieren geprüft; die Prüfung benötigt daher kein Schema und wird auch angewendet, wenn
+   *     keines verfügbar ist. Eine Eigenschaft, die im Payload fehlt oder als null angegeben ist,
+   *     bleibt ohne Wert und ist nicht betroffen. Da die Prüfung beim Dekodieren und nicht vor dem
+   *     Schreiben erfolgt, scheitert bei einem leeren Wert die gesamte Aktion – auch bei
+   *     Batch-Semantik – statt nur das betroffene Element zu überspringen.
+   * @default false
+   * @since v4.9
+   */
+  @Nullable
+  Boolean getRejectEmptyValues();
+
+  @JsonIgnore
+  @Value.Derived
+  @Value.Auxiliary
+  default boolean rejectsEmptyValues() {
+    return Boolean.TRUE.equals(getRejectEmptyValues());
+  }
 
   /**
    * @langEn Whitelist of feature properties that may be the target of a partial update (the

--- a/ogcapi-draft/ogcapi-transactions/src/test/groovy/de/ii/ogcapi/transactions/app/RejectEmptyUpdateValuesSpec.groovy
+++ b/ogcapi-draft/ogcapi-transactions/src/test/groovy/de/ii/ogcapi/transactions/app/RejectEmptyUpdateValuesSpec.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.transactions.app
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import de.ii.xtraplatform.features.domain.FeatureTransactions
+import de.ii.xtraplatform.features.domain.ImmutablePropertyUpdate
+import spock.lang.Specification
+
+/**
+ * A partial update carries the new values rather than a feature payload, so it never passes through
+ * a decoder and gets its own empty-value check under {@code Prefer: handling=strict}. The rejection
+ * is the platform one, so an update reads the same as a request body rejected while decoding.
+ */
+class RejectEmptyUpdateValuesSpec extends Specification {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+
+    private static FeatureTransactions.PropertyUpdate update(List<String> path, String json) {
+        return ImmutablePropertyUpdate.builder()
+                .path(path)
+                .value(Optional.of(MAPPER.readTree(json)))
+                .build()
+    }
+
+    private static FeatureTransactions.PropertyUpdate deletion(List<String> path) {
+        return ImmutablePropertyUpdate.builder().path(path).value(Optional.empty()).build()
+    }
+
+    def 'an empty scalar value is rejected and named by its canonical path'() {
+        when:
+        TransactionExecutorImpl.rejectEmptyValues([update(['lifetime', 'end'], '""')])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("The property 'lifetime.end' has an empty value")
+    }
+
+    def 'a value of only whitespace is rejected'() {
+        when:
+        TransactionExecutorImpl.rejectEmptyValues([update(['name'], '"   "')])
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def 'an empty entry of a multi-valued property is named by its index'() {
+        when:
+        TransactionExecutorImpl.rejectEmptyValues([update(['tags'], '["a","","c"]')])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("The property 'tags[1]' has an empty value")
+    }
+
+    def 'an empty member of an object-array entry is named by the full path'() {
+        when:
+        TransactionExecutorImpl.rejectEmptyValues([update(['addresses'], '[{"street":"Main"},{"street":""}]')])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.contains("The property 'addresses[1].street' has an empty value")
+    }
+
+    def 'an explicit delete sets null, which is not an empty value'() {
+        when:
+        TransactionExecutorImpl.rejectEmptyValues([deletion(['name'])])
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'values that are not strings cannot be empty'() {
+        when:
+        TransactionExecutorImpl.rejectEmptyValues([
+                update(['name'], '"Bonn"'),
+                update(['count'], '0'),
+                update(['flag'], 'false'),
+                update(['note'], 'null'),
+                update(['geometry'], '{"type":"Point","coordinates":[7.1,50.7]}')
+        ])
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'an empty list of updates passes'() {
+        when:
+        TransactionExecutorImpl.rejectEmptyValues([])
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/DecoderContext.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/DecoderContext.java
@@ -61,4 +61,15 @@ public interface DecoderContext {
   default Set<String> getReadOnlyProperties() {
     return Set.of();
   }
+
+  /**
+   * Whether a value that is a string with no characters or with only whitespace makes the request
+   * body invalid. Set from the {@code rejectEmptyValues} option of the building block that handles
+   * the request, and only ever for {@code Prefer: handling=strict}. The check rides the decoding of
+   * the body, so it costs no second parse of the content.
+   */
+  @Value.Default
+  default boolean getRejectEmptyValues() {
+    return false;
+  }
 }

--- a/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/EmptyValues.java
+++ b/ogcapi-stable/ogcapi-features-core/src/main/java/de/ii/ogcapi/features/core/domain/EmptyValues.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.features.core.domain;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import de.ii.xtraplatform.features.domain.pipeline.FeatureEventHandlerEmptyValues;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+/**
+ * Finds an empty value — a string with no characters or with only whitespace — in the value of a
+ * single property, for the one case that does not go through a decoder: a partial update, which
+ * carries the new values themselves instead of a feature payload.
+ *
+ * <p>A request body is checked while it is decoded, by {@link FeatureEventHandlerEmptyValues},
+ * which also defines what counts as empty and how a rejection reads.
+ */
+public final class EmptyValues {
+
+  private EmptyValues() {}
+
+  /**
+   * The path of the first empty value in {@code node}, or an empty {@code Optional} if it has none.
+   * Object members are joined with {@code .}, array members carry their index; the empty path of a
+   * scalar at the root is reported as {@code .}.
+   */
+  public static Optional<String> firstEmptyValue(JsonNode node) {
+    return firstEmptyValue(node, "");
+  }
+
+  /**
+   * Joins the path of the updated property with the path reported inside its value by {@link
+   * #firstEmptyValue(JsonNode)}.
+   */
+  public static String join(String path, String subPath) {
+    if (".".equals(subPath)) {
+      return path;
+    }
+    return subPath.startsWith("[") ? path + subPath : path + "." + subPath;
+  }
+
+  private static Optional<String> firstEmptyValue(JsonNode node, String path) {
+    if (node == null || node.isNull() || node.isMissingNode()) {
+      return Optional.empty();
+    }
+    if (node.isTextual()) {
+      return FeatureEventHandlerEmptyValues.isEmpty(node.textValue())
+          ? Optional.of(path.isEmpty() ? "." : path)
+          : Optional.empty();
+    }
+    if (node.isObject()) {
+      Iterator<Entry<String, JsonNode>> members = node.fields();
+      while (members.hasNext()) {
+        Entry<String, JsonNode> member = members.next();
+        Optional<String> found =
+            firstEmptyValue(
+                member.getValue(), path.isEmpty() ? member.getKey() : path + "." + member.getKey());
+        if (found.isPresent()) {
+          return found;
+        }
+      }
+    } else if (node.isArray()) {
+      for (int i = 0; i < node.size(); i++) {
+        Optional<String> found = firstEmptyValue(node.get(i), path + "[" + i + "]");
+        if (found.isPresent()) {
+          return found;
+        }
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/ogcapi-stable/ogcapi-features-core/src/test/groovy/de/ii/ogcapi/features/core/domain/EmptyValuesSpec.groovy
+++ b/ogcapi-stable/ogcapi-features-core/src/test/groovy/de/ii/ogcapi/features/core/domain/EmptyValuesSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.features.core.domain
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import spock.lang.Specification
+
+/**
+ * Finding an empty value in the value of an updated property — the one case that does not go through
+ * a decoder. A request body is checked while it is decoded, so what counts as empty is defined and
+ * exercised in {@code FeatureEventHandlerEmptyValues}.
+ */
+class EmptyValuesSpec extends Specification {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+
+    private Optional<String> firstEmptyValue(String json) {
+        return EmptyValues.firstEmptyValue(MAPPER.readTree(json))
+    }
+
+    def 'an empty string is an empty value'() {
+        expect:
+        firstEmptyValue('{"name":""}').get() == 'name'
+    }
+
+    def 'a string with only whitespace is an empty value'() {
+        expect:
+        firstEmptyValue('{"name":"  \\t\\n "}').get() == 'name'
+    }
+
+    def 'the path of a nested empty value joins the member names'() {
+        expect:
+        firstEmptyValue('{"properties":{"lifetime":{"end":""}}}').get() == 'properties.lifetime.end'
+    }
+
+    def 'the path of an empty value in an array carries its index'() {
+        expect:
+        firstEmptyValue('{"tags":["a","","c"]}').get() == 'tags[1]'
+    }
+
+    def 'the first empty value wins'() {
+        expect:
+        firstEmptyValue('{"a":"x","b":"","c":""}').get() == 'b'
+    }
+
+    def 'a scalar at the root has no path of its own'() {
+        expect:
+        firstEmptyValue('""').get() == '.'
+    }
+
+    def 'a body without empty values passes'() {
+        expect:
+        firstEmptyValue('''{
+            "type": "Feature",
+            "id": "1",
+            "geometry": {"type": "Point", "coordinates": [7.1, 50.7]},
+            "properties": {"name": "Bonn", "count": 0, "flag": false, "note": null, "tags": []}
+        }''').isEmpty()
+    }
+
+    def 'only strings can be empty'() {
+        expect:
+        firstEmptyValue('{"count":0,"flag":false,"note":null,"nested":{},"list":[]}').isEmpty()
+    }
+
+    def 'join appends a sub-path, an index without a separator'() {
+        expect:
+        EmptyValues.join('tags', '[1]') == 'tags[1]'
+        EmptyValues.join('addresses', '[1].street') == 'addresses[1].street'
+        EmptyValues.join('lifetime', 'end') == 'lifetime.end'
+        EmptyValues.join('name', '.') == 'name'
+    }
+
+}

--- a/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ogcapi/features/geojson/app/FeaturesFormatGeoJson.java
+++ b/ogcapi-stable/ogcapi-features-geojson/src/main/java/de/ii/ogcapi/features/geojson/app/FeaturesFormatGeoJson.java
@@ -426,7 +426,8 @@ public class FeaturesFormatGeoJson extends FeatureFormatExtension
             decoderContext.getCrs(),
             decoderContext.getAxes(),
             decoderContext.getSupportedCrs(),
-            decoderContext.getReadOnlyProperties()));
+            decoderContext.getReadOnlyProperties(),
+            decoderContext.getRejectEmptyValues()));
   }
 
   @Override

--- a/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/FeaturesFormatGml.java
+++ b/ogcapi-stable/ogcapi-features-gml/src/main/java/de/ii/ogcapi/features/gml/app/FeaturesFormatGml.java
@@ -730,7 +730,8 @@ public class FeaturesFormatGml extends FeatureFormatExtension implements Conform
                 config,
                 alternativeCrss(collectionData),
                 decoderContext.getSupportedCrs(),
-                decoderContext.getReadOnlyProperties())));
+                decoderContext.getReadOnlyProperties(),
+                decoderContext.getRejectEmptyValues())));
   }
 
   @Override
@@ -944,14 +945,15 @@ public class FeaturesFormatGml extends FeatureFormatExtension implements Conform
   // Package-private for unit testing of the GmlConfiguration → decoder-input-profile mapping.
   static FeatureTokenDecoderGmlInputProfile toInputProfile(
       GmlConfiguration config, List<EpsgCrs> alternativeCrss, List<EpsgCrs> supportedCrs) {
-    return toInputProfile(config, alternativeCrss, supportedCrs, Set.of());
+    return toInputProfile(config, alternativeCrss, supportedCrs, Set.of(), false);
   }
 
   static FeatureTokenDecoderGmlInputProfile toInputProfile(
       GmlConfiguration config,
       List<EpsgCrs> alternativeCrss,
       List<EpsgCrs> supportedCrs,
-      Set<String> readOnlyProperties) {
+      Set<String> readOnlyProperties,
+      boolean rejectEmptyValues) {
     Map<String, EpsgCrs> srsNameMappings =
         alternativeCrss.stream()
             .filter(crs -> crs.getAlternativeUri().isPresent())
@@ -975,6 +977,7 @@ public class FeaturesFormatGml extends FeatureFormatExtension implements Conform
         .srsNameMappings(srsNameMappings)
         .supportedCrs(supportedCrs)
         .readOnlyProperties(readOnlyProperties)
+        .rejectEmptyValues(rejectEmptyValues)
         .gmlIdPrefix(Objects.requireNonNullElse(config.getGmlIdPrefix(), ""))
         .codelistProperties(config.getCodelistProperties())
         .featureRefTemplate(Objects.requireNonNullElse(config.getFeatureRefTemplate(), ""))


### PR DESCRIPTION
### Pull request checklist

-   [x] Added/updated unit tests
-   [x] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

Closes #1767.

Depends on https://github.com/ldproxy/xtraplatform-spatial/pull/628.

`rejectEmptyValues` refuses a value that is a string without characters or with only whitespace. Like the schema validation it joins, the check only applies to a request with a `Prefer` header of "handling=strict"; unlike it, the check runs while the request body is decoded, so it needs no schema and also applies where none is available for the collection. A property the body omits, or states as null, is left without a value and is unaffected.

For a transaction it covers the payload of every insert and replace action as well as the values an update action sets. An update carries the values instead of a feature payload, so it never passes a decoder and is checked on the resolved values, reported the same way. Because the check rides the decoding rather than running before the write, an empty value fails the whole action, also under batch semantics, rather than skipping the item that carries it.

PATCH is not covered: it has no handling preference to opt in with.
