### PR TITLE
MCP: fix HTTP 500 on every request after schema validator upgrade

### DIFF
--- a/ogcapi-custom/ogcapi-mcp/src/main/java/de/ii/ogcapi/mcp/app/McpJsonSchemaValidator.java
+++ b/ogcapi-custom/ogcapi-mcp/src/main/java/de/ii/ogcapi/mcp/app/McpJsonSchemaValidator.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.mcp.app;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.Error;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SpecificationVersion;
+import io.modelcontextprotocol.json.schema.JsonSchemaValidator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Validates structured tool output against a tool's output schema.
+ *
+ * <p>The MCP SDK ships a default validator, but it is compiled against json-schema-validator 1.5.x,
+ * whose {@code SpecVersion.VersionFlag} was removed in 2.0. Since ogcapi-foundation exports 2.0.x,
+ * the default validator fails with a {@link NoClassDefFoundError} as soon as it is instantiated, so
+ * this implementation is passed to the server builder instead.
+ */
+public class McpJsonSchemaValidator implements JsonSchemaValidator {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(McpJsonSchemaValidator.class);
+
+  private final ObjectMapper objectMapper;
+  private final SchemaRegistry schemaRegistry;
+  private final Map<String, Schema> schemaCache;
+
+  public McpJsonSchemaValidator(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+    this.schemaRegistry = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12);
+    this.schemaCache = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public ValidationResponse validate(Map<String, Object> schema, Object structuredContent) {
+    if (schema == null) {
+      throw new IllegalArgumentException("Schema must not be null");
+    }
+    if (structuredContent == null) {
+      throw new IllegalArgumentException("Structured content must not be null");
+    }
+
+    try {
+      JsonNode content =
+          structuredContent instanceof String str
+              ? objectMapper.readTree(str)
+              : objectMapper.valueToTree(structuredContent);
+
+      List<Error> errors = getOrCreateSchema(schema).validate(content);
+
+      if (!errors.isEmpty()) {
+        return ValidationResponse.asInvalid(
+            "Validation failed: structuredContent does not match tool outputSchema. "
+                + "Validation errors: "
+                + errors);
+      }
+
+      return ValidationResponse.asValid(content.toString());
+
+    } catch (JsonProcessingException e) {
+      LOGGER.error("Failed to validate tool result: error parsing schema: {}", e.getMessage());
+      return ValidationResponse.asInvalid("Error parsing tool JSON Schema: " + e.getMessage());
+    } catch (Exception e) {
+      LOGGER.error("Failed to validate tool result: unexpected error: {}", e.getMessage());
+      return ValidationResponse.asInvalid("Unexpected validation error: " + e.getMessage());
+    }
+  }
+
+  private Schema getOrCreateSchema(Map<String, Object> schema) {
+    return schemaCache.computeIfAbsent(
+        cacheKey(schema),
+        key -> {
+          Schema compiled = schemaRegistry.getSchema(objectMapper.valueToTree(schema));
+          // validators are lazily created otherwise, which is not thread-safe
+          compiled.initializeValidators();
+          return compiled;
+        });
+  }
+
+  private String cacheKey(Map<String, Object> schema) {
+    if (schema.containsKey("$id")) {
+      return String.valueOf(schema.get("$id"));
+    }
+    return String.valueOf(schema.hashCode());
+  }
+}

--- a/ogcapi-custom/ogcapi-mcp/src/main/java/de/ii/ogcapi/mcp/app/McpServerImpl.java
+++ b/ogcapi-custom/ogcapi-mcp/src/main/java/de/ii/ogcapi/mcp/app/McpServerImpl.java
@@ -164,6 +164,7 @@ public class McpServerImpl implements McpServer, AppLifeCycle {
         io.modelcontextprotocol.server.McpServer.sync(transport)
             .serverInfo(appContext.getName(), appContext.getVersion())
             .capabilities(ServerCapabilities.builder().tools(true).build())
+            .jsonSchemaValidator(new McpJsonSchemaValidator(objectMapper))
             .build();
 
     for (McpTool tool : mcpSchema.getTools()) {

--- a/ogcapi-custom/ogcapi-mcp/src/test/groovy/de/ii/ogcapi/mcp/app/McpJsonSchemaValidatorSpec.groovy
+++ b/ogcapi-custom/ogcapi-mcp/src/test/groovy/de/ii/ogcapi/mcp/app/McpJsonSchemaValidatorSpec.groovy
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.ogcapi.mcp.app
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper
+import io.modelcontextprotocol.server.McpServer
+import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities
+import spock.lang.Specification
+
+class McpJsonSchemaValidatorSpec extends Specification {
+
+    static final ObjectMapper MAPPER = new ObjectMapper()
+
+    static final Map<String, Object> SCHEMA = [
+            type      : "object",
+            properties: [
+                    name: [type: "string"],
+                    area: [type: "number"]
+            ],
+            required  : ["name"]
+    ]
+
+    // the SDK default validator is compiled against json-schema-validator 1.5.x, whose
+    // SpecVersion was removed in 2.0; instantiating it threw NoClassDefFoundError, which
+    // surfaced as an HTTP 500 on the first request instead of failing at build time
+    def 'server can be built with the validator'() {
+        given:
+        def transport = HttpServletStatelessServerTransportJavaX.builder()
+                .jsonMapper(new JacksonMcpJsonMapper(MAPPER))
+                .messageEndpoint("/mcp")
+                .build()
+
+        when:
+        def server = McpServer.sync(transport)
+                .serverInfo("test", "1.0.0")
+                .capabilities(ServerCapabilities.builder().tools(true).build())
+                .jsonSchemaValidator(new McpJsonSchemaValidator(MAPPER))
+                .build()
+
+        then:
+        server.getServerInfo().name() == "test"
+        server.listTools().isEmpty()
+
+        cleanup:
+        server.close()
+    }
+
+    def 'structured content matching the schema is valid'() {
+        given:
+        def validator = new McpJsonSchemaValidator(MAPPER)
+
+        when:
+        def response = validator.validate(SCHEMA, [name: "France", area: 532308.3])
+
+        then:
+        response.valid()
+        response.errorMessage() == null
+        MAPPER.readTree(response.jsonStructuredOutput()).get("name").asText() == "France"
+    }
+
+    def 'structured content violating the schema is invalid'() {
+        given:
+        def validator = new McpJsonSchemaValidator(MAPPER)
+
+        when:
+        def response = validator.validate(SCHEMA, content)
+
+        then:
+        !response.valid()
+        response.errorMessage().contains("does not match tool outputSchema")
+
+        where:
+        description        | content
+        'wrong type'       | [name: "France", area: "not a number"]
+        'missing required' | [area: 532308.3]
+    }
+
+    def 'string content is parsed as json'() {
+        given:
+        def validator = new McpJsonSchemaValidator(MAPPER)
+
+        when:
+        def response = validator.validate(SCHEMA, '{"name":"France","area":532308.3}')
+
+        then:
+        response.valid()
+    }
+
+    def 'malformed string content is invalid rather than throwing'() {
+        given:
+        def validator = new McpJsonSchemaValidator(MAPPER)
+
+        when:
+        def response = validator.validate(SCHEMA, "not json at all")
+
+        then:
+        !response.valid()
+        response.errorMessage() != null
+    }
+
+    def 'a cached schema stays usable across calls'() {
+        given:
+        def validator = new McpJsonSchemaValidator(MAPPER)
+
+        expect:
+        validator.validate(SCHEMA, [name: "France"]).valid()
+        validator.validate(SCHEMA, [name: "Spain"]).valid()
+        !validator.validate(SCHEMA, [area: 1.0]).valid()
+    }
+
+    def 'null arguments are rejected'() {
+        given:
+        def validator = new McpJsonSchemaValidator(MAPPER)
+
+        when:
+        validator.validate(schema, content)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        schema | content
+        null   | [name: "France"]
+        SCHEMA | null
+    }
+}


### PR DESCRIPTION
### Pull request checklist

-   [x] Added/updated unit tests
-   [ ] Updated documentation
-   [x] All checks are passing


### Changes introduced by this PR

Closes #1769

The MCP SDK ships a default JsonSchemaValidator compiled against json-schema-validator 1.5.x. Its SpecVersion.VersionFlag was removed in 2.0, which ogcapi-foundation now exports, so instantiating the default validator failed with NoClassDefFoundError. Since the server is built lazily on the first request, this surfaced as an HTTP 500 on every call rather than at startup.

Pass our own validator, implemented against the 2.0 API and following SchemaValidatorImpl, so the SDK never loads the default one and no second json-schema-validator version enters the build.

